### PR TITLE
feat: allow disabling browser downloads via `PLAYWRIGHT_SKIP_BROWSER` envvar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camoufox-js",
-  "version": "0.1.3",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/__main__.ts
+++ b/src/__main__.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander';
 
 import { Camoufox } from './sync_api.js';
 import { existsSync, fstat, rmSync } from 'fs';
+import { getAsBooleanFromENV } from './utils.js';
 
 class CamoufoxUpdate extends CamoufoxFetcher {
     currentVerStr: string | null;
@@ -32,13 +33,12 @@ class CamoufoxUpdate extends CamoufoxFetcher {
     }
 
     isUpdateNeeded(): boolean {
-        if (this.currentVerStr === null) {
-            return true;
+        if (getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD', false)) {
+            console.log("Skipping browser download / update check due to PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD set!");
+            return false;
         }
-        if (this.currentVerStr !== this.verstr) {
-            return true;
-        }
-        return false;
+
+        return this.currentVerStr === null || this.currentVerStr !== this.verstr;
     }
 
     async update(): Promise<void> {

--- a/src/addons.ts
+++ b/src/addons.ts
@@ -2,6 +2,7 @@ import { InvalidAddonPath } from './exceptions.js';
 import { getPath, unzip, webdl } from './pkgman.js';
 import fs from 'fs';
 import { join } from 'path';
+import { getAsBooleanFromENV } from './utils.js';
 
 export const DefaultAddons = {
     /**
@@ -60,6 +61,11 @@ function getAddonPath(addonName: string): string {
 export function maybeDownloadAddons(
     addons: Record<string, string>, addonsList: string[] = []
 ): void {
+    if (getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD', false)) {
+        console.log("Skipping addon download due to PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD set!");
+        return
+    }
+
     for (const addonName in addons) {
         const addonPath = getAddonPath(addonName);
 

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import maxmind, { CityResponse } from 'maxmind';
 import xml2js from 'xml2js';
+import { getAsBooleanFromENV } from './utils.js';
 
 export const ALLOW_GEOIP = true;
 
@@ -172,6 +173,11 @@ export function geoipAllowed(): void {
 
 export async function downloadMMDB(): Promise<void> {
     geoipAllowed();
+
+    if (getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD', false)) {
+        console.log("Skipping GeoIP database download due to PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD set!");
+        return;
+    }
 
     const assetUrl = await (new MaxMindDownloader(MMDB_REPO).getAsset());
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,14 @@ function getEnvVars(configMap: ConfigMap, userAgentOS: string): EnvVars {
     return envVars;
 }
 
+export function getAsBooleanFromENV(name: string, defaultValue?: boolean | undefined): boolean {
+    const value = process.env[name];
+    if (value === 'false' || value === '0')
+        return false;
+    if (value)
+        return true;
+    return !!defaultValue;
+}
 
 interface Property {
     property: string;


### PR DESCRIPTION
Just like Playwright tooling, `camoufox-js` now reads `PLAYWRIGHT_SKIP_BROWSER` envvar. If this is present (and is not `0` or `false`), `camoufox-js fetch` will not download the browsers, GeoIP database, nor browser addons.