### PR TITLE
feat: update INSTALL_DIR to use platform-specific cache directory

### DIFF
--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -37,7 +37,7 @@ if (!(process.platform in OS_MAP)) {
 
 export const OS_NAME: 'mac' | 'win' | 'lin' = OS_MAP[process.platform];
 
-export const INSTALL_DIR: PathLike = user_cache_dir('camoufox');
+export const INSTALL_DIR: PathLike = userCacheDir('camoufox');
 export const LOCAL_DATA: PathLike = path.join(import.meta.dirname, 'data-files');
 
 export const OS_ARCH_MATRIX: { [key: string]: string[] } = {
@@ -275,7 +275,7 @@ export class CamoufoxFetcher extends GitHubDownloader {
     }
 }
 
-function user_cache_dir(appName: string): string {
+function userCacheDir(appName: string): string {
     if (OS_NAME === 'win') {
         return path.join(os.homedir(), 'AppData', 'Local', appName, appName, 'Cache');
     } else if (OS_NAME === 'mac') {

--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -37,7 +37,7 @@ if (!(process.platform in OS_MAP)) {
 
 export const OS_NAME: 'mac' | 'win' | 'lin' = OS_MAP[process.platform];
 
-export const INSTALL_DIR: PathLike = path.join(os.homedir(), '.cache', 'camoufox');
+export const INSTALL_DIR: PathLike = user_cache_dir('camoufox');
 export const LOCAL_DATA: PathLike = path.join(import.meta.dirname, 'data-files');
 
 export const OS_ARCH_MATRIX: { [key: string]: string[] } = {
@@ -275,6 +275,15 @@ export class CamoufoxFetcher extends GitHubDownloader {
     }
 }
 
+function user_cache_dir(appName: string): string {
+    if (OS_NAME === 'win') {
+        return path.join(os.homedir(), 'AppData', 'Local', appName, appName, 'Cache');
+    } else if (OS_NAME === 'mac') {
+        return path.join(os.homedir(), 'Library', 'Caches', appName);
+    } else {
+        return path.join(os.homedir(), '.cache', appName);
+    }
+}
 
 export function installedVerStr(): string {
     return Version.fromPath().fullString;


### PR DESCRIPTION
As we can see in https://github.com/daijro/camoufox/blob/cf28f7865880b958475a2e2f6f81904afa1faab0/pythonlib/camoufox/pkgman.py#L54.

The INSTALL_DIR should be set platform-specificly.