### PR TITLE
feat: make proxy option compatible with PlaywrightLaunchOptions format

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -387,7 +387,7 @@ export interface LaunchOptions {
     /** Proxy to use for the browser.
      * Note: If `geoip` is `true`, a request will be sent through this proxy to find the target IP.
      */
-    proxy?: string;
+    proxy?: string | PlaywrightLaunchOptions['proxy'];
 
     /** Cache previous pages, requests, etc. (uses more memory). */
     enable_cache?: boolean;
@@ -568,7 +568,7 @@ export async function launchOptions({
 
         // Find the user's IP address
         if (proxy) {
-            geoip = await publicIP(proxy)
+            geoip = await publicIP(typeof proxy === 'string' ? proxy : proxy.server)
         } else {
             geoip = await publicIP()
         }
@@ -591,7 +591,7 @@ export async function launchOptions({
     // This is a very bad idea; the warning cannot be ignored with i_know_what_im_doing.
     if (
         proxy &&
-        !proxy.includes('localhost') &&
+        !(typeof proxy === 'string' ? proxy : proxy.server).includes('localhost') &&
         !isDomainSet(config, 'geolocation:')
     ) {
         LeakWarning.warn('proxy_without_geoip');
@@ -692,11 +692,15 @@ export async function launchOptions({
 
     let pwProxy: any = undefined;
     if (proxy) {
-        let proxyUrl = new URL(proxy);
-        pwProxy = {
-            server: proxyUrl.origin,
-            username: proxyUrl.username,
-            password: proxyUrl.password,
+        if (typeof proxy === 'string') {
+            let proxyUrl = new URL(proxy);
+            pwProxy = {
+                server: proxyUrl.origin,
+                username: proxyUrl.username,
+                password: proxyUrl.password,
+            }
+        } else {
+            pwProxy = proxy;
         }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -576,8 +576,8 @@ export async function launchOptions({
             }
         } else {
             pwProxy = proxy;
-            // Copy from playwright
-            let url;
+            // Copy from playwright https://github.com/microsoft/playwright/blob/3873b72ac1441ca691f7594f0ed705bd84518f93/packages/playwright-core/src/server/browserContext.ts#L737-L747
+            let url: URL;
             try {
                 // new URL('127.0.0.1:8080') throws
                 // new URL('localhost:8080') fails to parse host or protocol


### PR DESCRIPTION
The current typings make it not easy to quickly migrate from playwright to camoufox-js