### PR TITLE
fix: handle the `os` option correctly

### DIFF
--- a/src/fingerprints.ts
+++ b/src/fingerprints.ts
@@ -2,10 +2,12 @@ import { join } from 'node:path';
 import { loadYaml } from './pkgman.js';
 import { Fingerprint, FingerprintGenerator, FingerprintGeneratorOptions, ScreenFingerprint } from 'fingerprint-generator';
 
+export const SUPPORTED_OS = ['linux', 'macos', 'windows'] as const;
+
 const BROWSERFORGE_DATA = loadYaml(join(import.meta.dirname, 'data-files', 'browserforge.yml'));
 const FP_GENERATOR = new FingerprintGenerator({
     browsers: ['firefox'],
-    operatingSystems: ['linux', 'macos', 'windows'],
+    operatingSystems: SUPPORTED_OS as any,
 });
 
 function randrange(min: number, max: number): number {
@@ -84,7 +86,7 @@ function handleWindowSize(fp: Fingerprint, outerWidth: number, outerHeight: numb
     fp.screen = sc;
 }
 
-export function generateFingerprint(window?: [number, number], config: FingerprintGeneratorOptions | {} = {}): Fingerprint {
+export function generateFingerprint(window?: [number, number], config?: Partial<FingerprintGeneratorOptions>): Fingerprint {
     if (window) {
         const { fingerprint } = FP_GENERATOR.getFingerprint(config);
         handleWindowSize(fingerprint, window[0], window[1]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@
 import path from 'path';
 import { DefaultAddons, addDefaultAddons, confirmPaths } from './addons.js';
 import { InvalidOS, InvalidPropertyType, NonFirefoxFingerprint, UnknownProperty } from './exceptions.js';
-import { fromBrowserforge, generateFingerprint } from './fingerprints.js';
+import { fromBrowserforge, generateFingerprint, SUPPORTED_OS } from './fingerprints.js';
 import { publicIP, validIPv4, validIPv6 } from './ip.js';
 import { geoipAllowed, getGeolocation, handleLocales } from './locale.js';
 import { OS_NAME, getPath, installedVerStr, launchPath } from './pkgman.js';
@@ -201,17 +201,22 @@ function checkCustomFingerprint(fingerprint: Fingerprint): void {
     LeakWarning.warn('custom_fingerprint', false);
 }
 
-function checkValidOS(os: string | string[]): void {
+function validateOS(os?: typeof SUPPORTED_OS[number] | (typeof SUPPORTED_OS[number])[]): (typeof SUPPORTED_OS[number])[] | undefined {
+    if (!os) return undefined;
+
     if (Array.isArray(os)) {
-        os.forEach(checkValidOS);
-        return;
+        os.every(validateOS);
+        return [...os];
     }
-    if (!os.toLowerCase()) {
+
+    if (os !== os.toLowerCase()) {
         throw new InvalidOS(`OS values must be lowercase: '${os}'`);
     }
-    if (!['windows', 'macos', 'linux'].includes(os)) {
+    if (!SUPPORTED_OS.includes(os)) {
         throw new InvalidOS(`Camoufox does not support the OS: '${os}'`);
     }
+
+    return [os];
 }
 
 function cleanLocals(data: Record<string, any>): Record<string, any> {
@@ -310,7 +315,7 @@ export interface LaunchOptions {
      * Can be "windows", "macos", "linux", or a list to randomly choose from.
      * Default: ["windows", "macos", "linux"]
      */
-    os?: string | string[];
+    os?: typeof SUPPORTED_OS[number] | (typeof SUPPORTED_OS[number])[];
 
     /** Whether to block all images. */
     block_images?: boolean;
@@ -514,13 +519,10 @@ export async function launchOptions({
         warnManualConfig(config);
     }
 
-    // Assert the target OS is valid
-    if (os) {
-        checkValidOS(os);
-    }
+    const operatingSystems = validateOS(os);
 
     // webgl_config requires OS to be set
-    else if (webgl_config) {
+    if (!os && webgl_config) {
         throw new Error('OS must be set when using webgl_config');
     }
 
@@ -548,7 +550,7 @@ export async function launchOptions({
             window,
             {
                 screen: screen || getScreenCons(headless || 'DISPLAY' in env),
-                os,
+                operatingSystems,
             }
         );
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,9 +209,6 @@ function validateOS(os?: typeof SUPPORTED_OS[number] | (typeof SUPPORTED_OS[numb
         return [...os];
     }
 
-    if (os !== os.toLowerCase()) {
-        throw new InvalidOS(`OS values must be lowercase: '${os}'`);
-    }
     if (!SUPPORTED_OS.includes(os)) {
         throw new InvalidOS(`Camoufox does not support the OS: '${os}'`);
     }
@@ -522,7 +519,7 @@ export async function launchOptions({
     const operatingSystems = validateOS(os);
 
     // webgl_config requires OS to be set
-    if (!os && webgl_config) {
+    if (!operatingSystems && webgl_config) {
         throw new Error('OS must be set when using webgl_config');
     }
 


### PR DESCRIPTION
Fixes a type mismatch between the Camoufox OS option (`os`) and the `fingerprint-generator` OS option (`operatingSystems`).

Closes #11 