### PR TITLE
Use playwright-core rather than playwright (unnecessary bloat) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "^4.1.0",
     "language-tags": "^2.0.1",
     "maxmind": "^4.3.24",
-    "playwright": "^1.50.1",
+    "playwright-core": "^1.52.0",
     "progress": "^2.0.3",
     "sqlite3": "^5.1.7",
     "ua-parser-js": "^2.0.2",

--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -3,7 +3,7 @@ import {
     BrowserContext,
     BrowserType,
     firefox
-} from 'playwright';
+} from 'playwright-core';
 
 import { LaunchOptions, launchOptions, syncAttachVD } from './utils.js';
 import { VirtualDisplay } from './virtdisplay.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ import { join } from 'path';
 import { UAParser } from 'ua-parser-js';
 import { Fingerprint, FingerprintGeneratorOptions } from 'fingerprint-generator';
 
-import { LaunchOptions as PlaywrightLaunchOptions } from 'playwright';
+import { LaunchOptions as PlaywrightLaunchOptions } from 'playwright-core';
 
 type Screen = FingerprintGeneratorOptions['screen'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,7 +855,7 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     language-tags: "npm:^2.0.1"
     maxmind: "npm:^4.3.24"
-    playwright: "npm:^1.50.1"
+    playwright-core: "npm:^1.52.0"
     progress: "npm:^2.0.3"
     rimraf: "npm:^6.0.1"
     sqlite3: "npm:^5.1.7"
@@ -1322,31 +1322,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -2316,27 +2297,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.50.1":
-  version: 1.50.1
-  resolution: "playwright-core@npm:1.50.1"
+"playwright-core@npm:^1.52.0":
+  version: 1.52.0
+  resolution: "playwright-core@npm:1.52.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/c158764257d870897c31807a830ddcc3f5aaf4376719e05aeada3489a01f751650b2dc43e027201a40405a1b075084e89f58cd3730a985a229efe9d8cecfe360
-  languageName: node
-  linkType: hard
-
-"playwright@npm:^1.50.1":
-  version: 1.50.1
-  resolution: "playwright@npm:1.50.1"
-  dependencies:
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.50.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    playwright: cli.js
-  checksum: 10c0/b292ee6e0d122748a3d024b85ace86a0d9c848fc4121685d90ffc5d43d6bcf13ed7dc7488b1055f69040599c420052306ccba6fabfe2f69a15fc109c55171207
+  checksum: 10c0/640945507e6ca2144e9f596b2a6ecac042c2fd3683ff99e6271e9a7b38f3602d415f282609d569456f66680aab8b3c5bb1b257d8fb63a7fc0ed648261110421f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As far as I'm aware, [playwright-core](https://www.npmjs.com/package/playwright-core) satisfies the current requirements of this project, since it does not use the browsers shipped with [playwright](https://www.npmjs.com/package/playwright) anyway. 

Requiring `playwright` just forces users to download browsers that they will not ever use with this library.