### PR TITLE
fixes #21

### DIFF
--- a/src/fingerprints.ts
+++ b/src/fingerprints.ts
@@ -73,8 +73,8 @@ export function fromBrowserforge(fingerprint: Fingerprint, ffVersion?: string): 
 
 function handleWindowSize(fp: Fingerprint, outerWidth: number, outerHeight: number): void {
     const sc: ExtendedScreen = { ...fp.screen, screenY: undefined };
-    sc.screenX += (sc.width - outerWidth) / 2;
-    sc.screenY = (sc.height - outerHeight) / 2;
+    sc.screenX += Math.floor((sc.width - outerWidth) / 2);
+    sc.screenY = Math.floor((sc.height - outerHeight) / 2);
     if (sc.innerWidth) {
         sc.innerWidth = Math.max(outerWidth - sc.outerWidth + sc.innerWidth, 0);
     }


### PR DESCRIPTION
Fixes #21. Adds flooring to match floor division (`//`) used by Python Camoufox library:

https://github.com/daijro/camoufox/blob/95cc4489d025471368412b035743bb59855b160e/pythonlib/camoufox/fingerprints.py#L113C5-L114C49