### PR TITLE
docs: add usage details to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,41 @@ This is the JavaScript client for Camoufox. It is a port of the Python wrapper (
 npm install camoufox-js
 ```
 
+## Usage 
+
+You can launch Playwright-controlled Camoufox using this package like this:
+
+```javascript
+import { Camoufox } from 'camoufox-js';
+
+// you might need to run `npx camoufox-js fetch` to download the browser after installing the package
+
+const browser = await Camoufox({
+    // custom camoufox options
+} as any);
+            
+const page = await browser.newPage(); // `page` is a Playwright Page instance
+```
+
+Alternatively, if you want to use additional Playwright launch options, you can launch the Camoufox instance like this:
+
+
+```javascript
+import { launchOptions } from 'camoufox-js';
+import { firefox } from 'playwright';
+
+// you might need to run `npx camoufox-js fetch` to download the browser after installing the package
+
+const browser = await firefox.launch({
+    launchOptions: await launchOptions({ /* Camoufox options */ }),
+    // other Playwright options
+});
+            
+const page = await browser.newPage(); // `page` is a Playwright Page instance
+```
+
 ## More info
 
-Check out https://github.com/daijro/camoufox for more information on Camoufox.
+See https://camoufox.com/ or https://github.com/daijro/camoufox for more information on Camoufox.
 
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,16 @@ import { Camoufox } from 'camoufox-js';
 
 const browser = await Camoufox({
     // custom camoufox options
-} as any);
+});
             
 const page = await browser.newPage(); // `page` is a Playwright Page instance
 ```
 
 Alternatively, if you want to use additional Playwright launch options, you can launch the Camoufox instance like this:
 
-
 ```javascript
 import { launchOptions } from 'camoufox-js';
-import { firefox } from 'playwright';
+import { firefox } from 'playwright-core';
 
 // you might need to run `npx camoufox-js fetch` to download the browser after installing the package
 


### PR DESCRIPTION
Adds usage example to the root readme file (see comments under #31).