### PR TITLE
feat: re-export playwright-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the JavaScript client for Camoufox. It is a port of the Python wrapper (
 npm install camoufox-js
 ```
 
-## Usage 
+## Usage
 
 You can launch Playwright-controlled Camoufox using this package like this:
 
@@ -20,23 +20,22 @@ import { Camoufox } from 'camoufox-js';
 const browser = await Camoufox({
     // custom camoufox options
 });
-            
+
 const page = await browser.newPage(); // `page` is a Playwright Page instance
 ```
 
 Alternatively, if you want to use additional Playwright launch options, you can launch the Camoufox instance like this:
 
 ```javascript
-import { launchOptions } from 'camoufox-js';
-import { firefox } from 'playwright-core';
+import { playwright, launchOptions } from 'camoufox-js';
 
 // you might need to run `npx camoufox-js fetch` to download the browser after installing the package
 
-const browser = await firefox.launch({
+const browser = await playwright.firefox.launch({
     ...await launchOptions({ /* Camoufox options */ }),
     // other Playwright options, overriding the Camoufox options
 });
-            
+
 const page = await browser.newPage(); // `page` is a Playwright Page instance
 ```
 
@@ -45,13 +44,12 @@ const page = await browser.newPage(); // `page` is a Playwright Page instance
 Camoufox can be ran as a remote websocket server. It can be accessed from other devices, and languages other than Python supporting the Playwright API.
 
 ```javascript
-import { launchServer } from 'camoufox-js';
-import { firefox } from 'playwright-core';
+import { playwright, launchServer } from 'camoufox-js';
 
 // you might need to run `npx camoufox-js fetch` to download the browser after installing the package
 
 const server = await launchServer({ port: 8888, ws_path: '/camoufox' });
-const browser = await firefox.connect(server.wsEndpoint());
+const browser = await playwright, firefox.connect(server.wsEndpoint());
 
 const page = await browser.newPage();
 
@@ -59,12 +57,10 @@ const page = await browser.newPage();
 // Use your browser instance as usual
 // ...
 
-await browser.close();  
+await browser.close();
 await server.close(); // Close the server when done
 ```
 
 ## More info
 
 See https://camoufox.com/ or https://github.com/daijro/camoufox for more information on Camoufox.
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Camoufox, NewBrowser } from './sync_api.js';
 export { launchOptions } from './utils.js';
 export { launchServer } from './server.js';
+export { default as playwright } from 'playwright-core';

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { Camoufox, launchServer } from '../src';
-import { firefox } from 'playwright-core';
+import { playwright, Camoufox, launchServer } from '../src';
 
 const TEST_CASES = [
     { os: 'linux', userAgentRegex: /Linux/i },
@@ -21,21 +20,21 @@ describe('virtual display', () => {
         expect(userAgent).toMatch(/Linux/i);
         await browser.close();
 
-    }, 10e3); 
+    }, 10e3);
 });
 
 describe('Fingerprint consistency', () => {
-    test.each(TEST_CASES)('User-Agent matches set OS ($os)', 
+    test.each(TEST_CASES)('User-Agent matches set OS ($os)',
         async ({os, userAgentRegex}) => {
             const browser = await Camoufox({
                 os,
                 headless: true,
             } as any);
-            
+
             const page = await browser.newPage();
 
             await page.goto('http://httpbin.org/user-agent');
-            
+
             const [httpAgent, jsAgent] = await page.evaluate(() => {
                 return [
                     JSON.parse(document.body.innerText)['user-agent'],
@@ -63,7 +62,7 @@ test('Playwright connects to Camoufox server', async () => {
         headless: true,
     });
 
-    const browser = await firefox.connect(server.wsEndpoint());
+    const browser = await playwright.firefox.connect(server.wsEndpoint());
     const page = await browser.newPage();
     await page.goto('http://httpbin.org/user-agent');
 


### PR DESCRIPTION
Fix https://github.com/apify/camoufox-js/issues/52, **but** B4nan proposed a better solution: [move `playwright-core` into `peerdependencies`](https://github.com/apify/camoufox-js/issues/52#issuecomment-2972453651).