### PR TITLE
feat: simplify persistent context usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ scripts/
 *.mmdb
 dist/
 .npmrc
-user_data/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/
 *.mmdb
 dist/
 .npmrc
+user_data/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camoufox-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -8,19 +8,19 @@ import {
 import { LaunchOptions, launchOptions, syncAttachVD } from './utils.js';
 import { VirtualDisplay } from './virtdisplay.js';
 
-export async function Camoufox(launch_options: LaunchOptions | { headless?: boolean | 'virtual' }) {
-    const { headless, ...launchOptions } = launch_options;
-    return NewBrowser(firefox, headless, {}, false, false, launchOptions);
+export async function Camoufox<UserDataDir extends string | undefined = undefined, ReturnType = UserDataDir extends string ? BrowserContext : Browser>(launch_options: LaunchOptions | { headless?: boolean | 'virtual', user_data_dir: UserDataDir } = {}): Promise<ReturnType> {
+    const { headless, user_data_dir, ...launchOptions } = launch_options;
+    return NewBrowser(firefox, headless, {}, user_data_dir ?? false, false, launchOptions);
 }
 
-export async function NewBrowser(
+export async function NewBrowser<UserDataDir extends string | false = false, ReturnType = UserDataDir extends string ? BrowserContext : Browser>(
     playwright: BrowserType<Browser>,
     headless: boolean | 'virtual' = false,
     fromOptions: Record<string, any> = {},
-    persistentContext: boolean = false,
+    userDataDir: UserDataDir = false as UserDataDir,
     debug: boolean = false,
     launch_options: LaunchOptions = {}
-): Promise<Browser | BrowserContext> {
+): Promise<ReturnType> {
     let virtualDisplay: VirtualDisplay | null = null;
 
     if (headless === 'virtual') {
@@ -35,8 +35,8 @@ export async function NewBrowser(
         fromOptions = await launchOptions({ debug, ...launch_options });
     }
 
-    if (persistentContext) {
-        const context = await playwright.launchPersistentContext('~/.crawlee/persistent-user-data-dir', fromOptions);
+    if (userDataDir || typeof userDataDir === 'string') {
+        const context = await playwright.launchPersistentContext(typeof userDataDir === 'string' ? userDataDir : '', fromOptions);
         return syncAttachVD(context, virtualDisplay);
     }
 

--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -35,8 +35,8 @@ export async function NewBrowser<UserDataDir extends string | false = false, Ret
         fromOptions = await launchOptions({ debug, ...launch_options });
     }
 
-    if (userDataDir || typeof userDataDir === 'string') {
-        const context = await playwright.launchPersistentContext(typeof userDataDir === 'string' ? userDataDir : '', fromOptions);
+    if (typeof userDataDir === 'string') {
+        const context = await playwright.launchPersistentContext(userDataDir, fromOptions);
         return syncAttachVD(context, virtualDisplay);
     }
 

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import { Camoufox, launchServer } from '../src';
 import { firefox } from 'playwright-core';
+import { mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const TEST_CASES = [
     { os: 'linux', userAgentRegex: /Linux/i },
@@ -75,9 +78,11 @@ test('Playwright connects to Camoufox server', async () => {
 }, 30e3);
 
 test('Persistent context works', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'user_data_'));
+
     {
         const context = await Camoufox({
-            user_data_dir: './user_data',
+            user_data_dir: userDataDir,
             headless: true,
         });
 
@@ -95,7 +100,7 @@ test('Persistent context works', async () => {
     
     {
         const context = await Camoufox({
-            user_data_dir: './user_data',
+            user_data_dir: userDataDir,
             headless: true,
         });
 


### PR DESCRIPTION
Adds `user_data_dir` option to `Camoufox` and `NewBrowser` methods, enabling persistent context creation and therefore session maintenance. 

Closes #55 