### PR TITLE
chore: add repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "keywords": [],
   "author": "",
+  "repository": "apify/camoufox-js",
   "license": "MPL-2.0",
   "description": "Experimental JS port of Camoufox for Python.",
   "packageManager": "yarn@4.9.2",


### PR DESCRIPTION
Add [`repository`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) in _package.json_ to have link to repository in [_npm_ page](https://www.npmjs.com/package/camoufox-js).