### PR TITLE
feat: Export LaunchOptions type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { Camoufox, NewBrowser } from './sync_api.js';
-export { launchOptions } from './utils.js';
+export { type LaunchOptions, launchOptions } from './utils.js';
 export { launchServer } from './server.js';


### PR DESCRIPTION
[`LaunchOptions`](https://github.com/apify/camoufox-js/blob/01d8799f1413b4afd3ccdbcd8c3c77abd0de8961/src/utils.ts#L309) is used in the [`launchOptions()`](https://github.com/apify/camoufox-js/blob/01d8799f1413b4afd3ccdbcd8c3c77abd0de8961/src/utils.ts#L445) function parameter, but `LaunchOptions` isn't exported.