### PR TITLE
fix: mac OS name is macOS

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ function determineUAOS(userAgent: string): 'mac' | 'win' | 'lin' {
     if (!parsedUA) {
         throw new Error("Could not determine OS from user agent");
     }
-    if (parsedUA.startsWith("Mac")) {
+    if (parsedUA.startsWith("macOS")) {
         return 'mac';
     }
     if (parsedUA.startsWith("Windows")) {


### PR DESCRIPTION
Fixes Mac user agents being incorrectly recognized as Linux OS, due to the OS name for Macs being incorrect.
"macOS" is how ua-parser-js identifies Macs: https://docs.uaparser.dev/info/os/name.html