### PR TITLE
feat: Add Bun runtime support via bun:sqlite

### DIFF
--- a/src/webgl/sample.ts
+++ b/src/webgl/sample.ts
@@ -1,20 +1,19 @@
 import path from "node:path";
-import type Database from "better-sqlite3";
+import type BetterSqlite3 from "better-sqlite3";
 import { OS_ARCH_MATRIX } from "../pkgman.js";
 
 // Declare Bun global for runtime detection (only exists when running in Bun)
 declare const Bun: unknown;
 
 // Cached Database constructor - loaded lazily on first use
-// Using `any` to support both better-sqlite3 and bun:sqlite constructors
-let DatabaseConstructor: (new (filename: string) => Database) | null = null;
+let DatabaseConstructor: typeof BetterSqlite3 | null = null;
 
 /**
  * Opens a SQLite database using the appropriate driver for the runtime.
  * Uses bun:sqlite in Bun, better-sqlite3 in Node.js.
  * The Database constructor is cached after first load.
  */
-async function openDatabase(pathName: string): Promise<Database> {
+async function openDatabase(pathName: string): Promise<BetterSqlite3.Database> {
 	if (!DatabaseConstructor) {
 		if (typeof Bun !== "undefined") {
 			// @ts-ignore - bun:sqlite only exists in Bun runtime
@@ -25,7 +24,8 @@ async function openDatabase(pathName: string): Promise<Database> {
 			DatabaseConstructor = NodeDatabase;
 		}
 	}
-	return new DatabaseConstructor(pathName) as Database;
+	// DatabaseConstructor is guaranteed to be set at this point
+	return new DatabaseConstructor!(pathName);
 }
 
 // Get database path relative to this file


### PR DESCRIPTION
## Summary

This PR adds support for running camoufox-js in the [Bun](https://bun.sh/) runtime by using `bun:sqlite` instead of `better-sqlite3` when running in Bun.

Closes #200

## Problem

Currently, camoufox-js fails when running in Bun because `better-sqlite3` is not supported by Bun (see [oven-sh/bun#4290](https://github.com/oven-sh/bun/issues/4290)). The error:

```
error: 'better-sqlite3' is not yet supported in Bun.
Track the status in https://github.com/oven-sh/bun/issues/4290
In the meantime, you could try bun:sqlite which has a similar API.
code: "ERR_DLOPEN_FAILED"
```

## Solution

Add runtime detection to use the appropriate SQLite driver:
- **Bun**: Use built-in `bun:sqlite`
- **Node.js**: Use `better-sqlite3` (unchanged behavior)

The APIs are compatible for the operations used in `sample.ts` (`new Database()`, `db.prepare().all()`, `db.close()`).

## Changes

- Modified `src/webgl/sample.ts` to dynamically import the SQLite driver based on runtime detection
- No changes to the public API
- Backward compatible with Node.js

## Testing

Tested with Bun v1.3.5 on macOS:
- `sampleWebGL()` works for all OS types (win/mac/lin)
- `getPossiblePairs()` works correctly
- Full browser launch and page navigation works via `launchOptions()`

**Note:** We are already using this patch internally in production and it has been working reliably for our Bun-based workers.

## Notes

- The `typeof Bun !== "undefined"` check is the standard way to detect the Bun runtime
- `better-sqlite3` remains a dependency for Node.js users
- No additional dependencies are required for Bun users (bun:sqlite is built-in)