### PR TITLE
fix: add `import.meta.dirname` fallback

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import tags from "language-tags";
 import maxmind, { type CityResponse } from "maxmind";
 import xml2js from "xml2js";
@@ -15,6 +16,9 @@ import { validateIP } from "./ip.js";
 import { GitHubDownloader, INSTALL_DIR, webdl } from "./pkgman.js";
 import { getAsBooleanFromENV } from "./utils.js";
 import { LeakWarning } from "./warnings.js";
+
+const currentDir =
+	import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
 export const ALLOW_GEOIP = true;
 
@@ -239,7 +243,7 @@ export async function getGeolocation(ip: string): Promise<Geolocation> {
 
 async function getUnicodeInfo(): Promise<any> {
 	const data = await fs.promises.readFile(
-		path.join(import.meta.dirname, "data-files", "territoryInfo.xml"),
+		path.join(currentDir, "data-files", "territoryInfo.xml"),
 	);
 	const parser = new xml2js.Parser();
 	return parser.parseStringPromise(data);

--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Writable } from "node:stream";
 import { setTimeout } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import AdmZip from "adm-zip";
 import ProgressBar from "progress";
 import { CONSTRAINTS } from "./__version__.js";
@@ -36,11 +37,11 @@ if (!(process.platform in OS_MAP)) {
 
 export const OS_NAME: "mac" | "win" | "lin" = OS_MAP[process.platform];
 
+const currentDir =
+	import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
+
 export const INSTALL_DIR: PathLike = userCacheDir("camoufox");
-export const LOCAL_DATA: PathLike = path.join(
-	import.meta.dirname,
-	"data-files",
-);
+export const LOCAL_DATA: PathLike = path.join(currentDir, "data-files");
 
 export const OS_ARCH_MATRIX: { [key: string]: string[] } = {
 	win: ["x86_64", "i686"],

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,4 +1,9 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import WARNINGS_DATA from "./mappings/warnings.config.js";
+
+const currentDir =
+	import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
 export class LeakWarning extends Error {
 	constructor(message: string) {
@@ -15,7 +20,7 @@ export class LeakWarning extends Error {
 			warning += "\nIf this is intentional, pass `iKnowWhatImDoing=true`.";
 		}
 
-		const currentModule = import.meta.dirname;
+		const currentModule = currentDir;
 		const originalStackTrace = Error.prepareStackTrace;
 		Error.prepareStackTrace = (_, stack) => stack;
 		const err = new Error();

--- a/src/webgl/sample.ts
+++ b/src/webgl/sample.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type BetterSqlite3 from "better-sqlite3";
 import { OS_ARCH_MATRIX } from "../pkgman.js";
 
@@ -29,12 +30,9 @@ async function openDatabase(pathName: string): Promise<BetterSqlite3.Database> {
 }
 
 // Get database path relative to this file
-const DB_PATH = path.join(
-	import.meta.dirname,
-	"..",
-	"data-files",
-	"webgl_data.db",
-);
+const currentDir =
+	import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = path.join(currentDir, "..", "data-files", "webgl_data.db");
 
 interface WebGLData {
 	vendor: string;


### PR DESCRIPTION
 ## Summary

When developing camoufox scripts with `camoufox-js` and `tsx`, it seems that `import.meta.dirname` is not preserved, causing path resolution to fail.

example:
  ```bash
  mkdir test && cd test
  npm init -y
  npm add camoufox-js tsx

  cat > test.ts << 'EOF'
  import { launch } from 'camoufox-js';

  async function main() {
    const browser = await launch({ headless: true });
    await browser.close();
  }

  main();
  EOF
  

  npx tsx test.ts
  # TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string.
  # Received undefined
```

##  Changes

Fallback to `path.dirname(fileURLToPath(import.meta.url))` when `import.meta.dirname` is not available.