### PR TITLE
fix: macOS timezone crash workaround

### DIFF
--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -55,14 +55,28 @@ export async function NewBrowser<
 		});
 	}
 
+	// Extract _timezoneId (non-Linux workaround for Camoufox binary timezone crash).
+	// TODO: Remove once the Camoufox binary fixes timezone-spoofing.patch.
+	const timezoneId = fromOptions._timezoneId as string | undefined;
+	delete fromOptions._timezoneId;
+
 	if (typeof userDataDir === "string") {
 		const context = await playwright.launchPersistentContext(
 			userDataDir,
-			fromOptions,
+			{ ...fromOptions, ...(timezoneId ? { timezoneId } : {}) },
 		);
 		return syncAttachVD(context, virtualDisplay);
 	}
 
 	const browser = await playwright.launch(fromOptions);
+
+	// Monkey-patch newContext to inject timezoneId on non-Linux.
+	// TODO: Remove once the Camoufox binary fixes timezone-spoofing.patch.
+	if (timezoneId) {
+		const originalNewContext = browser.newContext.bind(browser);
+		browser.newContext = (options?: any) =>
+			originalNewContext({ timezoneId, ...options });
+	}
+
 	return syncAttachVD(browser, virtualDisplay);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -757,6 +757,18 @@ export async function launchOptions({
 	// Validate the config
 	validateConfig(config, executable_path);
 
+	// On non-Linux, the Camoufox binary's C++ ICU timezone patch
+	// (timezone-spoofing.patch) crashes due to a reinterpret_cast from
+	// char16_t* to char* in TimeZone.cpp. Extract timezone from the config
+	// and pass it via Playwright's timezoneId context option instead.
+	// TODO: Remove this workaround once the Camoufox binary fixes the
+	// timezone-spoofing.patch for non-Linux platforms.
+	let _timezoneId: string | undefined;
+	if (OS_NAME !== "lin" && "timezone" in config) {
+		_timezoneId = config.timezone as string;
+		delete config.timezone;
+	}
+
 	//Prepare environment variables to pass to Camoufox
 	const env_vars = {
 		...getEnvVars(config, targetOS),
@@ -770,22 +782,28 @@ export async function launchOptions({
 		executable_path = launchPath();
 	}
 
-	const out: PlaywrightLaunchOptions = {
+	const out: PlaywrightLaunchOptions & { _timezoneId?: string } = {
 		executablePath: executable_path,
 		args: args,
 		env: env_vars as any,
 		firefoxUserPrefs: firefox_user_prefs,
-		proxy: proxyUrl
-			? {
-					server: proxyUrl.origin,
-					username: proxyUrl.username,
-					password: proxyUrl.password,
-					bypass: typeof proxy === "string" ? undefined : proxy?.bypass,
-				}
-			: undefined,
 		headless: headlessBoolean,
 		...launch_options,
 	};
+
+	if (_timezoneId) {
+		out._timezoneId = _timezoneId;
+	}
+
+	// Only include proxy if defined (Playwright 1.55+ validates this)
+	if (proxyUrl) {
+		out.proxy = {
+			server: proxyUrl.origin,
+			username: proxyUrl.username,
+			password: proxyUrl.password,
+			bypass: typeof proxy === "string" ? undefined : proxy?.bypass,
+		};
+	}
 
 	return out;
 }


### PR DESCRIPTION
## Summary
- Extracts timezone from Camoufox config on non-Linux platforms and passes it via Playwright's `timezoneId` context option, avoiding a crash in the binary's C++ ICU timezone patch
- Restructures proxy output to be conditional (Playwright 1.55+ validates undefined proxy values)
- Adds monkey-patching of `browser.newContext` to inject `timezoneId` for non-persistent contexts

## Test plan
- [ ] Verify browser launches without crash on macOS with timezone-based geoip config
- [ ] Verify timezone is correctly spoofed via Playwright context option
- [ ] Verify persistent contexts receive timezoneId
- [ ] Verify Linux behavior is unchanged (timezone stays in config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)