### PR TITLE
feat: merging new features/fixes from cloverlabs camoufox fork | per-context fingerprint spoofing for CloverLabs builds

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,211 @@
+/**
+ * Per-context fingerprint helpers for CloverLabs Camoufox builds.
+ *
+ * These utilities generate `addInitScript` code that calls the self-destructing
+ * `window.setXxx()` functions available in CloverLabs builds with per-context
+ * fingerprint isolation.
+ *
+ * Usage with Playwright:
+ *   const context = await browser.newContext();
+ *   await applyContextFingerprint(context, fingerprint);
+ *
+ * Or apply individual overrides:
+ *   await context.addInitScript(setCanvasSeed(12345));
+ */
+
+/** Generate init script for per-context canvas fingerprint seed */
+export function setCanvasSeed(seed: number): string {
+	return `window.setCanvasSeed?.(${seed});`;
+}
+
+/** Generate init script for per-context audio fingerprint seed */
+export function setAudioFingerprintSeed(seed: number): string {
+	return `window.setAudioFingerprintSeed?.(${seed});`;
+}
+
+/** Generate init script for per-context font spacing seed */
+export function setFontSpacingSeed(seed: number): string {
+	return `window.setFontSpacingSeed?.(${seed});`;
+}
+
+/** Generate init script for per-context font list */
+export function setFontList(fonts: string[]): string {
+	return `window.setFontList?.(${JSON.stringify(fonts)});`;
+}
+
+/** Generate init script for per-context navigator.platform */
+export function setNavigatorPlatform(platform: string): string {
+	return `window.setNavigatorPlatform?.(${JSON.stringify(platform)});`;
+}
+
+/** Generate init script for per-context navigator.oscpu */
+export function setNavigatorOscpu(oscpu: string): string {
+	return `window.setNavigatorOscpu?.(${JSON.stringify(oscpu)});`;
+}
+
+/** Generate init script for per-context navigator.hardwareConcurrency */
+export function setNavigatorHardwareConcurrency(cores: number): string {
+	return `window.setNavigatorHardwareConcurrency?.(${cores});`;
+}
+
+/** Generate init script for per-context WebGL vendor */
+export function setWebGLVendor(vendor: string): string {
+	return `window.setWebGLVendor?.(${JSON.stringify(vendor)});`;
+}
+
+/** Generate init script for per-context WebGL renderer */
+export function setWebGLRenderer(renderer: string): string {
+	return `window.setWebGLRenderer?.(${JSON.stringify(renderer)});`;
+}
+
+/** Generate init script for per-context screen dimensions */
+export function setScreenDimensions(width: number, height: number): string {
+	return `window.setScreenDimensions?.(${width}, ${height});`;
+}
+
+/** Generate init script for per-context screen color depth */
+export function setScreenColorDepth(depth: number): string {
+	return `window.setScreenColorDepth?.(${depth});`;
+}
+
+/** Generate init script for per-context screen available dimensions */
+export function setScreenAvailDimensions(
+	width: number,
+	height: number,
+): string {
+	return `window.setScreenAvailDimensions?.(${width}, ${height});`;
+}
+
+/** Generate init script for per-context timezone */
+export function setTimezone(tz: string): string {
+	return `window.setTimezone?.(${JSON.stringify(tz)});`;
+}
+
+/** Generate init script for per-context speech voices */
+export function setSpeechVoices(voices: string[]): string {
+	return `window.setSpeechVoices?.(${JSON.stringify(voices)});`;
+}
+
+/** Generate init script for per-context WebRTC IPv4 */
+export function setWebRTCIPv4(ip: string): string {
+	return `window.setWebRTCIPv4?.(${JSON.stringify(ip)});`;
+}
+
+/** Generate init script for per-context WebRTC IPv6 */
+export function setWebRTCIPv6(ip: string): string {
+	return `window.setWebRTCIPv6?.(${JSON.stringify(ip)});`;
+}
+
+/**
+ * Configuration for per-context fingerprint overrides.
+ * All fields are optional - only provided fields will be applied.
+ */
+export interface ContextFingerprint {
+	/** Canvas fingerprint seed */
+	canvasSeed?: number;
+	/** Audio fingerprint seed */
+	audioSeed?: number;
+	/** Font spacing seed */
+	fontSpacingSeed?: number;
+	/** List of fonts to appear "installed" */
+	fonts?: string[];
+	/** navigator.platform value */
+	platform?: string;
+	/** navigator.oscpu value */
+	oscpu?: string;
+	/** navigator.hardwareConcurrency (CPU cores) */
+	hardwareConcurrency?: number;
+	/** WebGL UNMASKED_VENDOR_WEBGL */
+	webglVendor?: string;
+	/** WebGL UNMASKED_RENDERER_WEBGL */
+	webglRenderer?: string;
+	/** Screen width and height */
+	screen?: { width: number; height: number };
+	/** Screen color depth */
+	colorDepth?: number;
+	/** Available screen dimensions */
+	availScreen?: { width: number; height: number };
+	/** Timezone identifier (e.g. "America/New_York") */
+	timezone?: string;
+	/** Speech synthesis voices list */
+	speechVoices?: string[];
+	/** WebRTC IPv4 address */
+	webrtcIPv4?: string;
+	/** WebRTC IPv6 address */
+	webrtcIPv6?: string;
+}
+
+/**
+ * Apply per-context fingerprint overrides to a Playwright BrowserContext.
+ * Only works with CloverLabs Camoufox builds that support per-context spoofing.
+ *
+ * Uses optional chaining (`?.`) so calls are silently ignored on standard builds.
+ */
+export async function applyContextFingerprint(
+	context: { addInitScript: (script: string) => Promise<void> },
+	fingerprint: ContextFingerprint,
+): Promise<void> {
+	const scripts: string[] = [];
+
+	if (fingerprint.canvasSeed != null) {
+		scripts.push(setCanvasSeed(fingerprint.canvasSeed));
+	}
+	if (fingerprint.audioSeed != null) {
+		scripts.push(setAudioFingerprintSeed(fingerprint.audioSeed));
+	}
+	if (fingerprint.fontSpacingSeed != null) {
+		scripts.push(setFontSpacingSeed(fingerprint.fontSpacingSeed));
+	}
+	if (fingerprint.fonts) {
+		scripts.push(setFontList(fingerprint.fonts));
+	}
+	if (fingerprint.platform) {
+		scripts.push(setNavigatorPlatform(fingerprint.platform));
+	}
+	if (fingerprint.oscpu) {
+		scripts.push(setNavigatorOscpu(fingerprint.oscpu));
+	}
+	if (fingerprint.hardwareConcurrency != null) {
+		scripts.push(
+			setNavigatorHardwareConcurrency(fingerprint.hardwareConcurrency),
+		);
+	}
+	if (fingerprint.webglVendor) {
+		scripts.push(setWebGLVendor(fingerprint.webglVendor));
+	}
+	if (fingerprint.webglRenderer) {
+		scripts.push(setWebGLRenderer(fingerprint.webglRenderer));
+	}
+	if (fingerprint.screen) {
+		scripts.push(
+			setScreenDimensions(fingerprint.screen.width, fingerprint.screen.height),
+		);
+	}
+	if (fingerprint.colorDepth != null) {
+		scripts.push(setScreenColorDepth(fingerprint.colorDepth));
+	}
+	if (fingerprint.availScreen) {
+		scripts.push(
+			setScreenAvailDimensions(
+				fingerprint.availScreen.width,
+				fingerprint.availScreen.height,
+			),
+		);
+	}
+	if (fingerprint.timezone) {
+		scripts.push(setTimezone(fingerprint.timezone));
+	}
+	if (fingerprint.speechVoices) {
+		scripts.push(setSpeechVoices(fingerprint.speechVoices));
+	}
+	if (fingerprint.webrtcIPv4) {
+		scripts.push(setWebRTCIPv4(fingerprint.webrtcIPv4));
+	}
+	if (fingerprint.webrtcIPv6) {
+		scripts.push(setWebRTCIPv6(fingerprint.webrtcIPv6));
+	}
+
+	if (scripts.length > 0) {
+		await context.addInitScript(scripts.join("\n"));
+	}
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -96,6 +96,28 @@ export function setWebRTCIPv6(ip: string): string {
 	return `window.setWebRTCIPv6?.(${JSON.stringify(ip)});`;
 }
 
+/** Generate init script for per-context navigator.userAgent */
+export function setNavigatorUserAgent(ua: string): string {
+	return `window.setNavigatorUserAgent?.(${JSON.stringify(ua)});`;
+}
+
+/** Generate init script for per-context geolocation */
+export function setGeolocation(
+	lat: number,
+	lon: number,
+	accuracy?: number,
+): string {
+	if (accuracy != null) {
+		return `window.setGeolocation?.(${lat}, ${lon}, ${accuracy});`;
+	}
+	return `window.setGeolocation?.(${lat}, ${lon});`;
+}
+
+/** Generate init script for per-context locale */
+export function setLocale(locale: string): string {
+	return `window.setLocale?.(${JSON.stringify(locale)});`;
+}
+
 /**
  * Configuration for per-context fingerprint overrides.
  * All fields are optional - only provided fields will be applied.
@@ -133,6 +155,12 @@ export interface ContextFingerprint {
 	webrtcIPv4?: string;
 	/** WebRTC IPv6 address */
 	webrtcIPv6?: string;
+	/** navigator.userAgent override */
+	userAgent?: string;
+	/** Geolocation override */
+	geolocation?: { latitude: number; longitude: number; accuracy?: number };
+	/** Locale/language override */
+	locale?: string;
 }
 
 /**
@@ -203,6 +231,21 @@ export async function applyContextFingerprint(
 	}
 	if (fingerprint.webrtcIPv6) {
 		scripts.push(setWebRTCIPv6(fingerprint.webrtcIPv6));
+	}
+	if (fingerprint.userAgent) {
+		scripts.push(setNavigatorUserAgent(fingerprint.userAgent));
+	}
+	if (fingerprint.geolocation) {
+		scripts.push(
+			setGeolocation(
+				fingerprint.geolocation.latitude,
+				fingerprint.geolocation.longitude,
+				fingerprint.geolocation.accuracy,
+			),
+		);
+	}
+	if (fingerprint.locale) {
+		scripts.push(setLocale(fingerprint.locale));
 	}
 
 	if (scripts.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,23 @@
+export { DefaultAddons } from "./addons.js";
+export {
+	type ContextFingerprint,
+	applyContextFingerprint,
+	setAudioFingerprintSeed,
+	setCanvasSeed,
+	setFontList,
+	setFontSpacingSeed,
+	setNavigatorHardwareConcurrency,
+	setNavigatorOscpu,
+	setNavigatorPlatform,
+	setScreenColorDepth,
+	setScreenDimensions,
+	setSpeechVoices,
+	setTimezone,
+	setWebGLRenderer,
+	setWebGLVendor,
+	setWebRTCIPv4,
+	setWebRTCIPv6,
+} from "./context.js";
 export { launchServer } from "./server.js";
 export { Camoufox, NewBrowser } from "./sync_api.js";
 export { type LaunchOptions, launchOptions } from "./utils.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,9 @@ export {
 	setWebGLVendor,
 	setWebRTCIPv4,
 	setWebRTCIPv6,
+	setNavigatorUserAgent,
+	setGeolocation,
+	setLocale,
 } from "./context.js";
 export { launchServer } from "./server.js";
 export { Camoufox, NewBrowser } from "./sync_api.js";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -737,11 +737,23 @@ export async function launchOptions({
 		});
 	}
 
-	// Canvas anti-fingerprinting
-	mergeInto(config, {
-		"canvas:aaOffset": Math.floor(Math.random() * 101) - 50, // nosec
-		"canvas:aaCapOffset": true,
-	});
+	// Set canvas and audio seeds (used by CloverLabs builds for per-context spoofing).
+	// Only set if the binary's properties.json supports them.
+	const knownProperties = loadProperties(executable_path);
+	if ("canvas:seed" in knownProperties) {
+		setInto(
+			config,
+			"canvas:seed",
+			Math.floor(Math.random() * 1_073_741_824),
+		);
+	}
+	if ("audio:seed" in knownProperties) {
+		setInto(
+			config,
+			"audio:seed",
+			Math.floor(Math.random() * 1_073_741_824),
+		);
+	}
 
 	// Cache previous pages, requests, etc (uses more memory)
 	if (enable_cache) {


### PR DESCRIPTION
## Summary

Ports per-context fingerprint spoofing features from the [CloverLabs Camoufox fork](https://github.com/CloverLabsAI/camoufox) to this TypeScript wrapper library.

### Source commits from CloverLabs fork

| Commit | Date | Description |
|--------|------|-------------|
| `27f6d32` | Feb 3, 2026 | Per-context audio fingerprinting and screen spoofing patches (`AudioFingerprintManager`, `ScreenDimensionManager`) |
| `dd5decd` | Feb 10, 2026 | Timezone/geolocation/locale spoofing merge — per-context timezone with worker propagation, geolocation, locale |
| `d0401db` | Feb 11, 2026 | Per-context canvas spoofing (`CanvasFingerprintManager`, `RoverfoxStorageManager`) |
| `7a7d143` | Feb 20, 2026 | Final per-context hardware fingerprint spoofing — navigator (platform, oscpu, hardwareConcurrency), WebGL (vendor/renderer), font list, speech voices, screen enhancements |
| `62334d2` | Mar 2, 2026 | Per-context user agent spoofing (`NavigatorManager` extension) |
| `7f12ab2` | Mar 7, 2026 | Add `audio:seed` and `canvas:seed` to property schema — enables Playwright protocol support for per-context seeds |

### CloverLabs architecture

The per-context system works through Juggler protocol extensions in `additions/juggler/` (`BrowserHandler.js`, `TargetRegistry.js`, `content/main.js`) with C++ managers that store per-context values keyed by `BrowsingContext.OriginAttributes.mUserContextId` via `RoverfoxStorageManager`.

### Per-context APIs ported (19 total)

| Function | Source commit | Browser API |
|---|---|---|
| `setCanvasSeed(seed)` | `d0401db` | `window.setCanvasSeed()` |
| `setAudioFingerprintSeed(seed)` | `27f6d32` | `window.setAudioFingerprintSeed()` |
| `setFontSpacingSeed(seed)` | `7a7d143` | `window.setFontSpacingSeed()` |
| `setFontList(fonts)` | `7a7d143` | `window.setFontList()` |
| `setNavigatorPlatform(platform)` | `7a7d143` | `window.setNavigatorPlatform()` |
| `setNavigatorOscpu(oscpu)` | `7a7d143` | `window.setNavigatorOscpu()` |
| `setNavigatorHardwareConcurrency(cores)` | `7a7d143` | `window.setNavigatorHardwareConcurrency()` |
| `setNavigatorUserAgent(ua)` | `62334d2` | `window.setNavigatorUserAgent()` |
| `setWebGLVendor(vendor)` | `7a7d143` | `window.setWebGLVendor()` |
| `setWebGLRenderer(renderer)` | `7a7d143` | `window.setWebGLRenderer()` |
| `setScreenDimensions(w, h)` | `27f6d32` | `window.setScreenDimensions()` |
| `setScreenColorDepth(depth)` | `27f6d32` | `window.setScreenColorDepth()` |
| `setScreenAvailDimensions(w, h)` | `7a7d143` | `window.setScreenAvailDimensions()` |
| `setTimezone(tz)` | `dd5decd` | `window.setTimezone()` |
| `setGeolocation(lat, lon, accuracy)` | `dd5decd` | `window.setGeolocation()` |
| `setLocale(locale)` | `dd5decd` | `window.setLocale()` |
| `setSpeechVoices(voices)` | `7a7d143` | `window.setSpeechVoices()` |
| `setWebRTCIPv4(ip)` | `7a7d143` | `window.setWebRTCIPv4()` |
| `setWebRTCIPv6(ip)` | `7a7d143` | `window.setWebRTCIPv6()` |

### Changes

- Adds `src/context.ts` with per-context fingerprint override utilities and `ContextFingerprint` interface
- Exports `applyContextFingerprint`, `ContextFingerprint`, `DefaultAddons`, and 19 individual `set*` functions
- Detects canvas/audio seed support from binary's `properties.json` and sets random seeds per launch
- Replaces old `canvas:aaOffset` anti-fingerprinting with per-context `canvas:seed`
- All functions use optional chaining (`?.`) so calls are silently ignored on standard (non-CloverLabs) builds

## Test plan
- [ ] Verify new exports are accessible from the package
- [ ] Verify canvas/audio seeds are set when binary supports them
- [ ] Verify standard (non-CloverLabs) builds still work without canvas:seed support
- [ ] Verify `applyContextFingerprint` applies all 19 overrides correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)