### PR TITLE
fix: config env is not properly being passed and memory leak

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -760,7 +760,7 @@ export async function launchOptions({
 	//Prepare environment variables to pass to Camoufox
 	const env_vars = {
 		...getEnvVars(config, targetOS),
-		...process.env,
+		...env,
 	};
 
 	// Prepare the executable path

--- a/src/virtdisplay.ts
+++ b/src/virtdisplay.ts
@@ -41,7 +41,6 @@ export class VirtualDisplay {
 			"XVideo-MotionCompensation",
 			"-extension",
 			"XINERAMA",
-			"-shmem",
 			"-fp",
 			"built-ins",
 			"-nocursor",


### PR DESCRIPTION
# Fix DISPLAY env var being dropped when custom `env` is passed, and remove `-shmem` to prevent shared memory leaks

## What's broken

### 1. `headless: "virtual"` doesn't work when you also pass a custom `env`

If you call `Camoufox({ headless: "virtual", env: { ...process.env, MY_VAR: "value" } })`, the browser crashes with:

```
Error: no DISPLAY environment variable specified
```

The virtual display code correctly sets `env.DISPLAY` on line 317 of `utils.js`, but then on line 479 the final environment passed to the browser is built from `process.env` instead of the `env` parameter — so the DISPLAY gets thrown away.

It works when you don't pass a custom `env` because in that case `env` is literally `process.env` (assigned on line 309), so mutating `env.DISPLAY` mutates `process.env` too. But as soon as you pass your own env object, the DISPLAY goes nowhere.

### 2. `-shmem` in Xvfb args leaks shared memory on ungraceful exits

The `-shmem` flag tells Xvfb to use shared memory for its framebuffer. The problem is that when Xvfb gets killed hard (SIGKILL, crash, orphaned after parent dies), those shared memory segments stick around forever. Over time they pile up, and eventually the system runs out of shared memory segments entirely. At that point every new Xvfb fails with:

```
shmget: No space left on device
Fatal server error: Couldn't add screen 0
```

On my server, I hit this issue and found over 4,000 orphaned segments, all 3,236 bytes from dead Xvfb instances.

## The fix

### `utils.js:479` — use `env` instead of `process.env`

```diff
 const env_vars = {
     ...getEnvVars(config, targetOS),
-    ...process.env,
+    ...env,
 };
```

### `virtdisplay.js` — drop `-shmem` from the Xvfb args

Xvfb works fine without it and won't leak shared memory when killed.

```diff
 xvfb_args = [
     "-screen", "0", "1x1x24",
     ...
-    "-shmem",
     "-fp", "built-ins",
     ...
 ]
```

## How we tested this

### env fix

Launched with `Camoufox({ headless: "virtual", env: { ...process.env, CUSTOM: "val" } })`. Without the fix it fails immediately. With the fix the browser starts and runs normally.

### shmem fix — clean shutdown

Ran a full test, let it finish cleanly. Shared memory count stayed at baseline. No leaked segments.

### shmem fix — hard kill

Started a test, waited for Xvfb + browser to be running, then sent SIGKILL to the parent process. The Xvfb became an orphan (expected), but after killing it too, shared memory returned to baseline — zero leaked segments. Before this fix, every hard kill left behind a permanent orphaned segment.
