### PR TITLE
fix: use `node:sqlite` with Deno exclusively

### DIFF
--- a/src/webgl/sample.ts
+++ b/src/webgl/sample.ts
@@ -3,31 +3,27 @@ import { fileURLToPath } from "node:url";
 import { OS_ARCH_MATRIX } from "../pkgman.js";
 
 declare const Bun: unknown;
+declare const Deno: unknown;
 
 interface SqliteDatabase {
 	prepare(query: string): { all(...params: any[]): any[] };
 	close(): void;
 }
 
-let DatabaseConstructor: (new (path: string) => SqliteDatabase) | null = null;
-
 async function openDatabase(pathName: string): Promise<SqliteDatabase> {
-	if (!DatabaseConstructor) {
-		if (typeof Bun !== "undefined") {
-			// @ts-expect-error - bun:sqlite only exists in Bun runtime
-			const { Database: BunDatabase } = await import("bun:sqlite");
-			DatabaseConstructor = BunDatabase;
-		} else {
-			try {
-				const { DatabaseSync } = await import("node:sqlite");
-				DatabaseConstructor = DatabaseSync;
-			} catch {
-				const { default: NodeDatabase } = await import("better-sqlite3");
-				DatabaseConstructor = NodeDatabase;
-			}
-		}
+	if (typeof Bun !== "undefined") {
+		// @ts-expect-error - bun:sqlite only exists in Bun runtime
+		const { Database: BunDatabase } = await import("bun:sqlite");
+		return new BunDatabase(pathName);
 	}
-	return new DatabaseConstructor!(pathName);
+
+	if (typeof Deno !== "undefined") {
+		const { DatabaseSync } = await import("node:sqlite");
+		return new DatabaseSync(pathName);
+	}
+
+	const { default: BetterSqlite3 } = await import("better-sqlite3");
+	return new BetterSqlite3(pathName);
 }
 
 // Get database path relative to this file

--- a/src/webgl/sample.ts
+++ b/src/webgl/sample.ts
@@ -10,20 +10,23 @@ interface SqliteDatabase {
 	close(): void;
 }
 
+let DatabaseConstructor: (new (path: string) => SqliteDatabase) | null = null;
+
 async function openDatabase(pathName: string): Promise<SqliteDatabase> {
-	if (typeof Bun !== "undefined") {
-		// @ts-expect-error - bun:sqlite only exists in Bun runtime
-		const { Database: BunDatabase } = await import("bun:sqlite");
-		return new BunDatabase(pathName);
+	if (!DatabaseConstructor) {
+		if (typeof Bun !== "undefined") {
+			// @ts-expect-error - bun:sqlite only exists in Bun runtime
+			const { Database: BunDatabase } = await import("bun:sqlite");
+			DatabaseConstructor = BunDatabase;
+		} else if (typeof Deno !== "undefined") {
+			const { DatabaseSync } = await import("node:sqlite");
+			DatabaseConstructor = DatabaseSync;
+		} else {
+			const { default: BetterSqlite3 } = await import("better-sqlite3");
+			DatabaseConstructor = BetterSqlite3;
+		}
 	}
-
-	if (typeof Deno !== "undefined") {
-		const { DatabaseSync } = await import("node:sqlite");
-		return new DatabaseSync(pathName);
-	}
-
-	const { default: BetterSqlite3 } = await import("better-sqlite3");
-	return new BetterSqlite3(pathName);
+	return new DatabaseConstructor!(pathName);
 }
 
 // Get database path relative to this file


### PR DESCRIPTION
Forces the use of `better-sqlite3` when running under Node. Importing `node:sqlite` in Node now prints warning messages, which might cause confusion when using Camoufox as a (nested) dependency.

Closes #269 