### PR TITLE
fix: race condition with xvfb displays

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
 		"useIgnoreFile": false
 	},
 	"files": {
-		"ignoreUnknown": false
+		"ignoreUnknown": false,
+		"includes": ["src/**/*.ts", "test/**/*.ts"]
 	},
 	"formatter": {
 		"enabled": true,
@@ -14,7 +15,6 @@
 	},
 	"linter": {
 		"enabled": true,
-		"includes": ["src/**/*.ts", "tests/**/*.ts"],
 		"rules": {
 			"recommended": true,
 			"suspicious": {

--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -44,7 +44,7 @@ export async function NewBrowser<
 
 	if (headless === "virtual") {
 		virtualDisplay = new VirtualDisplay(debug);
-		launch_options.virtual_display = virtualDisplay.get();
+		launch_options.virtual_display = await virtualDisplay.get();
 	}
 
 	if (!fromOptions || Object.keys(fromOptions).length === 0) {

--- a/src/virtdisplay.ts
+++ b/src/virtdisplay.ts
@@ -1,9 +1,6 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { randomInt } from "node:crypto";
-import { existsSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { globSync } from "glob";
+import { accessSync, constants as fsConstants } from "node:fs";
+import type { Readable } from "node:stream";
 import {
 	CannotExecuteXvfb,
 	CannotFindXvfb,
@@ -11,11 +8,13 @@ import {
 } from "./exceptions.js";
 import { OS_NAME } from "./pkgman.js";
 
+// Safe timeout for xvfb writing display num, prevents infinite hang
+const DISPLAYFD_READ_TIMEOUT_MS = 10_000;
+
 export class VirtualDisplay {
 	private debug: boolean;
 	private proc: ChildProcess | null = null;
 	private _display: number | null = null;
-	// private _lock = new Lock();
 
 	constructor(debug: boolean = false) {
 		this.debug = debug;
@@ -49,88 +48,101 @@ export class VirtualDisplay {
 	}
 
 	private get xvfb_path(): string {
-		const path = execFileSync("which", ["Xvfb"]).toString().trim();
-		if (!path) {
+		let resolved: string;
+		try {
+			resolved = execFileSync("which", ["Xvfb"]).toString().trim();
+		} catch {
 			throw new CannotFindXvfb("Please install Xvfb to use headless mode.");
 		}
-		if (!existsSync(path) || !execFileSync("test", ["-x", path])) {
+		if (!resolved) {
+			throw new CannotFindXvfb("Please install Xvfb to use headless mode.");
+		}
+		try {
+			accessSync(resolved, fsConstants.X_OK);
+		} catch {
 			throw new CannotExecuteXvfb(
-				`I do not have permission to execute Xvfb: ${path}`,
+				`I do not have permission to execute Xvfb: ${resolved}`,
 			);
 		}
-		return path;
-	}
-
-	private get xvfb_cmd(): string[] {
-		return [this.xvfb_path, `:${this.display}`, ...this.xvfb_args];
-	}
-
-	private execute_xvfb(): void {
-		if (this.debug) {
-			console.log("Starting virtual display:", this.xvfb_cmd.join(" "));
-		}
-		this.proc = spawn(this.xvfb_cmd[0], this.xvfb_cmd.slice(1), {
-			stdio: this.debug ? "inherit" : "ignore",
-			detached: true,
-		});
-	}
-
-	public get(): string {
-		VirtualDisplay.assert_linux();
-
-		// this._lock.runExclusive(() => {
-		if (!this.proc) {
-			this.execute_xvfb();
-		} else if (this.debug) {
-			console.log(`Using virtual display: ${this.display}`);
-		}
-		// });
-
-		return `:${this.display}`;
-	}
-
-	public kill(): void {
-		// this._lock.runExclusive(() => {
-		if (this.proc && !this.proc.killed) {
-			if (this.debug) {
-				console.log("Terminating virtual display:", this.display);
-			}
-			this.proc.kill();
-		}
-		// });
+		return resolved;
 	}
 
 	/**
-	 * Get list of lock files in /tmp
-	 * @returns List of lock file paths
+	 * Launch Xvfb with -displayfd 3 so the kernel/Xvfb itself picks a free
+	 * display number atomically and reports it back to us. Avoids userspace race conditions
 	 */
-	public static _get_lock_files(): string[] {
-		const tmpd = process.env.TMPDIR || tmpdir();
-		try {
-			return globSync(path.join(tmpd, ".X*-lock")).filter((p) => {
-				try {
-					return statSync(p).isFile();
-				} catch {
-					return false;
+	private spawnXvfb(): ChildProcess {
+		const xvfbPath = this.xvfb_path;
+		const cmd = [xvfbPath, "-displayfd", "3", ...this.xvfb_args];
+		if (this.debug) {
+			console.log("Starting virtual display:", cmd.join(" "));
+		}
+		// Force Mesa software GLX to avoid GPU contention delays, we don't use the GPU anyways
+		return spawn(cmd[0], cmd.slice(1), {
+			stdio: [
+				"ignore",
+				this.debug ? "inherit" : "ignore",
+				this.debug ? "inherit" : "ignore",
+				"pipe", // fd 3 — Xvfb writes "<display>\n" here
+			],
+			detached: true,
+			env: {
+				...process.env,
+				__GLX_VENDOR_LIBRARY_NAME: "mesa",
+				LIBGL_ALWAYS_SOFTWARE: "1",
+			},
+		});
+	}
+
+	public async get(): Promise<string> {
+		VirtualDisplay.assert_linux();
+
+		if (!this.proc) {
+			this.proc = this.spawnXvfb();
+			const stream = this.proc.stdio[3] as Readable;
+			const timer = setTimeout(
+				() =>
+					stream.destroy(
+						new CannotExecuteXvfb(
+							`Xvfb did not report a display within ${DISPLAYFD_READ_TIMEOUT_MS}ms`,
+						),
+					),
+				DISPLAYFD_READ_TIMEOUT_MS,
+			);
+			let buf = "";
+			try {
+				for await (const chunk of stream) {
+					buf += chunk;
+					if (buf.includes("\n")) break;
 				}
-			});
-		} catch {
-			return [];
+			} catch (err) {
+				this.kill();
+				throw err;
+			} finally {
+				clearTimeout(timer);
+			}
+			const n = Number.parseInt(buf, 10);
+			if (!Number.isFinite(n)) {
+				this.kill();
+				throw new CannotExecuteXvfb(
+					`Xvfb did not report a display (got ${JSON.stringify(buf)}, exit=${this.proc.exitCode})`,
+				);
+			}
+			this._display = n;
+		} else if (this.debug) {
+			console.log(`Using virtual display: ${this._display}`);
 		}
+
+		return `:${this._display}`;
 	}
 
-	private static _free_display(): number {
-		const ls = VirtualDisplay._get_lock_files().map((x) =>
-			parseInt(x.split("X")[1].split("-")[0], 10),
-		);
-		return ls.length ? Math.max(99, Math.max(...ls) + randomInt(3, 20)) : 99;
-	}
-
-	private get display(): number {
-		if (this._display === null) {
-			this._display = VirtualDisplay._free_display();
+	public kill(): void {
+		if (this.proc && this.proc.exitCode === null && !this.proc.killed) {
+			if (this.debug) {
+				console.log("Terminating virtual display:", this._display);
+			}
+			this.proc.kill();
 		}
-		return this._display;
 	}
 
 	private static assert_linux(): void {

--- a/test/virtdisplay.test.ts
+++ b/test/virtdisplay.test.ts
@@ -1,0 +1,132 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, test } from "vitest";
+import { VirtualDisplay } from "../src/virtdisplay";
+
+// VIRTDISPLAY_TEST_N controls the concurrent-launch count. Default is
+// kept low so the test passes on any developer box; set to 1000 (or
+// whatever) to exercise real scaling. At high N you will need
+// `ulimit -n` headroom — each Xvfb takes one X11 socket plus our
+// -displayfd pipe.
+const N = Number.parseInt(process.env.VIRTDISPLAY_TEST_N ?? "50", 10);
+
+// Track every VirtualDisplay we spawn so afterEach can guarantee
+// cleanup even if an assertion fails mid-test.
+const tracked = new Set<VirtualDisplay>();
+
+function track(vd: VirtualDisplay): VirtualDisplay {
+	tracked.add(vd);
+	return vd;
+}
+
+function killAllTracked(): void {
+	for (const vd of tracked) {
+		try {
+			vd.kill();
+		} catch {
+			// best effort
+		}
+	}
+	tracked.clear();
+}
+
+// Reach into the private proc to inspect process liveness — needed to
+// assert kill() actually terminated Xvfb.
+function procOf(vd: VirtualDisplay) {
+	return (vd as unknown as { proc: { exitCode: number | null; pid?: number } })
+		.proc;
+}
+
+async function waitForExit(vd: VirtualDisplay, timeoutMs = 5_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (procOf(vd).exitCode !== null) return;
+		await sleep(25);
+	}
+}
+
+describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
+	afterEach(() => {
+		killAllTracked();
+	});
+
+	test("single launch returns a valid display and kill terminates Xvfb", async () => {
+		const vd = track(new VirtualDisplay());
+		const display = await vd.get();
+		expect(display).toMatch(/^:\d+$/);
+		expect(procOf(vd).exitCode).toBeNull();
+
+		vd.kill();
+		await waitForExit(vd);
+		tracked.delete(vd);
+		expect(procOf(vd).exitCode).not.toBeNull();
+	}, 15_000);
+
+	test("get() is idempotent within one VirtualDisplay", async () => {
+		const vd = track(new VirtualDisplay());
+		const a = await vd.get();
+		const b = await vd.get();
+		expect(a).toBe(b);
+	}, 15_000);
+
+	test(
+		`${N} concurrent reservations all get unique displays`,
+		async () => {
+			// Every VirtualDisplay spawns its own Xvfb. Each Xvfb scans up
+			// from :0 and atomically claims the first free X11 socket
+			// (kernel-mediated bind, no userspace race). -displayfd reports
+			// the chosen number back to us. A duplicate here would mean we
+			// mis-parsed or mis-routed the displayfd output, or two Xvfbs
+			// somehow bound the same socket.
+			const vds = Array.from({ length: N }, () => track(new VirtualDisplay()));
+
+			const displays = await Promise.all(vds.map((vd) => vd.get()));
+
+			for (const d of displays) {
+				expect(d).toMatch(/^:\d+$/);
+			}
+
+			const unique = new Set(displays);
+			expect(unique.size).toBe(displays.length);
+
+			// Every Xvfb is alive.
+			for (const vd of vds) {
+				expect(procOf(vd).exitCode).toBeNull();
+			}
+
+			// Tear them all down and confirm every Xvfb actually exited —
+			// no leaked processes.
+			for (const vd of vds) vd.kill();
+			await Promise.all(vds.map((vd) => waitForExit(vd)));
+			tracked.clear();
+
+			for (const vd of vds) {
+				expect(procOf(vd).exitCode).not.toBeNull();
+			}
+		},
+		// Spawning thousands of Xvfb processes is genuinely slow.
+		Math.max(5_000, N * 200),
+	);
+
+	test("released display numbers can be reused on the next launch", async () => {
+		const a = track(new VirtualDisplay());
+		const aDisplay = await a.get();
+
+		a.kill();
+		await waitForExit(a);
+		tracked.delete(a);
+
+		// Spawning a new Xvfb after release must succeed. The new display
+		// number may or may not equal aDisplay — Xvfb's allocation order
+		// is its concern — but we must get *some* display.
+		const b = track(new VirtualDisplay());
+		const bDisplay = await b.get();
+		expect(bDisplay).toMatch(/^:\d+$/);
+
+		b.kill();
+		await waitForExit(b);
+		tracked.delete(b);
+
+		// Sanity: aDisplay was a valid form too.
+		expect(aDisplay).toMatch(/^:\d+$/);
+	}, 15_000);
+});


### PR DESCRIPTION
TLDR:
[IMPORTANT BUG FIX] - existing code has race condition where multiple browsers get the same display if started at the same time => when one browser closes, the display is closed too => kills other live browser as well. Switching to the native and atomic displayfd makes way more sense, I'm surprised this wasn't the default method.

AI description:

Replace the userspace lock-file scan + random-jitter retry loop in VirtualDisplay with Xvfb's own -displayfd mechanism. Xvfb scans up from :0 and atomically binds the first free X11 socket (kernel-mediated, no userspace race), then writes the chosen display number back through an inherited pipe (fd 3).

This eliminates the duplicate-display race that occurred when many camoufox processes started concurrently and all observed the same set of free display numbers before any of them bound.

Drops the userspace lock-file directory scan and random-jitter retry loop (no Node equivalents of _get_lock_files / _free_display remain).
Adds a 10s read timeout (DISPLAYFD_READ_TIMEOUT_MS) on the displayfd pipe so a hung Xvfb fails fast instead of blocking forever — implemented via setTimeout that calls stream.destroy() on the fd 3 Readable.
Forces software GLX (__GLX_VENDOR_LIBRARY_NAME=mesa, LIBGL_ALWAYS_SOFTWARE=1) — Xvfb doesn't use the GPU, but on hosts with NVIDIA libGLvnd this avoids an rwlock stall on Xvfb startup.
Detaches the child via detached: true on spawn() so a parent SIGINT doesn't propagate to Xvfb mid-bind.
This supersedes #595, which had a noisy force-push history from iterating on the prior lock-file approach.

Test plan
New test file, all pass

 single launch: get() returns :N and kill() actually terminates Xvfb
 get() is idempotent within one VirtualDisplay instance
 50 concurrent new VirtualDisplay() reservations all return unique displays (also verified locally at VIRTDISPLAY_TEST_N=200)
 released display numbers can be reused on the next launch

Link to PR from main camoufox: https://github.com/daijro/camoufox/pull/597 