### PR TITLE
fix: improve warning message on missing Camoufox binary

### DIFF
--- a/src/__main__.ts
+++ b/src/__main__.ts
@@ -45,8 +45,14 @@ class CamoufoxUpdate extends CamoufoxFetcher {
 
 	async update(): Promise<void> {
 		if (!this.isUpdateNeeded()) {
-			console.log("Camoufox binaries up to date!");
-			console.log(`Current version: v${this.currentVerStr}`);
+			if (this.currentVerStr === null) {
+				console.log(
+					`No cached Camoufox binary found at ${INSTALL_DIR}. Provision it before launching, or unset PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD to download.`,
+				);
+			} else {
+				console.log("Camoufox binaries up to date!");
+				console.log(`Current version: v${this.currentVerStr}`);
+			}
 			return;
 		}
 

--- a/src/__main__.ts
+++ b/src/__main__.ts
@@ -49,6 +49,12 @@ class CamoufoxUpdate extends CamoufoxFetcher {
 				console.log(
 					`No cached Camoufox binary found at ${INSTALL_DIR}. Provision it before launching, or unset PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD to download.`,
 				);
+			} else if (
+				getAsBooleanFromENV("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", false)
+			) {
+				console.log(
+					`Using cached Camoufox v${this.currentVerStr} (update check skipped).`,
+				);
 			} else {
 				console.log("Camoufox binaries up to date!");
 				console.log(`Current version: v${this.currentVerStr}`);


### PR DESCRIPTION
Logs a better error message on missing Camoufox binary (e.g. due to the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` envvar).

Closes #274 