### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
                     registry-url: 'https://registry.npmjs.org'
 
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.1.1
+                uses: apify/actions/pnpm-install@v1.1.2
 
             -   name: Run TypeScript build
                 run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
                     registry-url: 'https://registry.npmjs.org'
 
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.1.0
+                uses: apify/actions/pnpm-install@v1.1.1
 
             -   name: Run TypeScript build
                 run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
                     registry-url: 'https://registry.npmjs.org'
 
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.0.0
+                uses: apify/actions/pnpm-install@v1.1.0
 
             -   name: Run TypeScript build
                 run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
                   package-manager-cache: false
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Check formatting + linting
               run: pnpm check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
                   package-manager-cache: false
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Check formatting + linting
               run: pnpm check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
                   package-manager-cache: false
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Check formatting + linting
               run: pnpm check


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.