### PR TITLE
feat!: support Camoufox 150 builds, Node 26; drop Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24, 26]
         steps:
             - name: Checkout code
               uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"url": "https://github.com/apify/camoufox-js/issues"
 	},
 	"engines": {
-		"node": ">= 20"
+		"node": ">= 22"
 	},
 	"license": "MPL-2.0",
 	"description": "Experimental JS port of Camoufox for Python.",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"packageManager": "pnpm@10.33.4",
 	"dependencies": {
 		"adm-zip": "^0.5.16",
-		"better-sqlite3": "^12.2.0",
+		"better-sqlite3": "^12.10.0",
 		"cli-progress": "^3.12.0",
 		"commander": "^14.0.0",
 		"fingerprint-generator": "^2.1.66",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.5.16
         version: 0.5.17
       better-sqlite3:
-        specifier: ^12.2.0
-        version: 12.9.0
+        specifier: ^12.10.0
+        version: 12.10.0
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -347,9 +347,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1168,7 +1168,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.18: {}
 
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/src/__version__.ts
+++ b/src/__version__.ts
@@ -6,7 +6,7 @@ export class CONSTRAINTS {
 	/**
 	 * The minimum and maximum supported versions of the Camoufox browser.
 	 */
-	static readonly MIN_VERSION: string = "beta.19";
+	static readonly MIN_VERSION: string = "alpha.1";
 	static readonly MAX_VERSION: string = "1";
 
 	static asRange(): string {


### PR DESCRIPTION
## What

- **Support Camoufox 150 (Firefox 150) builds.** Lower `CONSTRAINTS.MIN_VERSION` from `beta.19` to `alpha.1`, mirroring upstream daijro/camoufox. Camoufox publishes its 150 builds with `alpha.*` asset suffixes, and the old range rejected them (`alpha` sorts before `beta`), so the wrapper kept installing the older Firefox 135 beta build.
- **Bump `better-sqlite3` to `^12.10.0`** so the native addon installs on Node 26 (older versions have no Node 26 prebuilt and fail to compile there).
- **Drop Node 20, add Node 26 to CI.** `better-sqlite3` 12.10.0 no longer ships a Node 20 prebuilt (ABI `v115`), so Node 20 falls back to a source build that fails in CI; Node 20 is also already deprecated on GitHub Actions runners.

## Why

camoufox-js was effectively pinned to the Firefox 135 beta build. Recent Playwright (1.60) bundles/expects **Firefox 150**, and driving camoufox's Firefox 135 with it crashes inside playwright-core (`pageError.location.url` on uncaught page errors — the Cloudflare challenge reliably emits one). Selecting the Camoufox 150 build aligns the Firefox versions and resolves the crash.

Verified locally: the fetcher now resolves `150.0.2-alpha.25`, FF150 installs on Node 26, and a Playwright crawler driving it through a Cloudflare challenge runs crash-free.

> **BREAKING CHANGE:** minimum supported Node.js version is now 22.

Context: unblocks apify/crawlee#3629 (`handleCloudflareChallenge`).