### PR TITLE
chore: bump impit to `0.14.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"commander": "^14.0.0",
 		"fingerprint-generator": "^2.1.66",
 		"glob": "^13.0.0",
-		"impit": "^0.13.0",
+		"impit": "^0.14.1",
 		"language-tags": "^2.0.1",
 		"maxmind": "^5.0.0",
 		"pretty-bytes": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.6
       impit:
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.14.1
+        version: 0.14.1
       language-tags:
         specifier: ^2.0.1
         version: 2.1.0
@@ -481,60 +481,60 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  impit-darwin-arm64@0.13.0:
-    resolution: {integrity: sha512-th0HuWJzbfrUiU+BRi03aYXGWm+uo1o3OzWaXAr8mFPwmqOhs58IkqH0xRlP0RnsFq8wt/4g5WbE0sQH3i1zBg==}
+  impit-darwin-arm64@0.14.1:
+    resolution: {integrity: sha512-K3KXto3gzR60kOFFxRmuxPNl3sPhdTLLpjBIW3RKD6vJFiGV5YH/T218WBECygPxRaIhESfsxfcOYrP53bHgFw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  impit-darwin-x64@0.13.0:
-    resolution: {integrity: sha512-EOZnUICnhwIlKuYrHU3M1ezhqK9+vLzYyPfAg0x+KAdfu0NRttHuqXij8UULuYQVFC+JQi0FFkmTovTHNxYHTg==}
+  impit-darwin-x64@0.14.1:
+    resolution: {integrity: sha512-k+w8SBHUtLX3KbzsCqSmcwitHfbOXXsLryL++KVahtFqU5D93T1buoTANnd63/mm5dNyadecIGG0MQ7SwvWx8g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  impit-linux-arm64-gnu@0.13.0:
-    resolution: {integrity: sha512-CW7JRoBGSKhfN7wt+XtYD1mst1Z6P0w7IooUO31nIbGz9iOwjidULi1K8GusmUqNVQOA9h69IjRd0xQrLNz2Qw==}
+  impit-linux-arm64-gnu@0.14.1:
+    resolution: {integrity: sha512-yBT7h6cVHL/hefzI/qjJc22fKP386O0inReOpUzCnb4SGnwhEHvL9nJk3OzU2prO9vvKNKSb6vfRBcvQ8HHH1g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-arm64-musl@0.13.0:
-    resolution: {integrity: sha512-9xotzDECmGtRwsUChjApo/v8+oslQwdg65rk1ti5yOhCTenGq3zMzErjZkome7OiOGFamJdhyg6RUxvmFtgvFA==}
+  impit-linux-arm64-musl@0.14.1:
+    resolution: {integrity: sha512-lFatihYntVIN814AnoNm/hSw5iONLKt6XtaAaJahZNdJOU+zsclcg9pbK0/61aENamkpIBpok/H8j5Sw/Xjuuw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  impit-linux-x64-gnu@0.13.0:
-    resolution: {integrity: sha512-Melcw+hbzGPYxSHLwPRLF9LjKmvzgvnq86qNocwxrEsgtunccehn/Xf4b9I+TJg4KSFnMfZq9OsjrQg5bRK14A==}
+  impit-linux-x64-gnu@0.14.1:
+    resolution: {integrity: sha512-oioVQzHqSi68BzxRpVLbNv9HRgOxAA21QNlzCMyeEM3/c02MkURCQ1W66yAlEFOR1gaqPZDJi/ymnmIGk6+PjQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-x64-musl@0.13.0:
-    resolution: {integrity: sha512-MSK+REPpWGjRbtEO94nL1uI9JSzq6E43VpfHerGXC5IO6E9xFBMKDeAOHjTEAQBbsaqpWDOBCfEjoaeUvRkmqQ==}
+  impit-linux-x64-musl@0.14.1:
+    resolution: {integrity: sha512-v7fBi405zZepQo0LqH51H+aXc/MYEtrQviIK+34kEqFBYOaSC9+wFZrs6A4WwrF9DaUuRZ3klisljwglN7rxDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  impit-win32-arm64-msvc@0.13.0:
-    resolution: {integrity: sha512-xTyhKcprmjfdp6nFF1Jn8gZ3Ig1CpwYpDzpGiTs0gPYz8NIt1qUwnKT7MFErOn47jSblPdYJeanbxFbelAlcyw==}
+  impit-win32-arm64-msvc@0.14.1:
+    resolution: {integrity: sha512-W4kPvvra8dXDdtJQbkxWPCCouUlZpOrLqHsJ7gc8CwAr69ljZqw6v+qB395nCD1rn3u32dV4d4fjBsyMdolQoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  impit-win32-x64-msvc@0.13.0:
-    resolution: {integrity: sha512-q/WFS05LhLnYeQr9fV7skVlpHd2ei1QGOtCSIGiFtOWGXGNJ8/9j4k8ehUBV3GrwYEKyflygKQ7cZNeobZ5hUQ==}
+  impit-win32-x64-msvc@0.14.1:
+    resolution: {integrity: sha512-gwzWsaORyzq294t8CCxfHAmqulnQNQZK8ad8YM6oQaGVXeUFa8r/ZnR+PglfYcrYF/GbYwGrf9U8StUU8KFLmQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  impit@0.13.0:
-    resolution: {integrity: sha512-usW4/VjIPbs8js01DShcYmYnL/7p4k/Bm73Wrwh18qyiYJ6AKJaS6npN7YBxIzkBEgJYMg9aqUC1lKtFsnT2rw==}
+  impit@0.14.1:
+    resolution: {integrity: sha512-ooFuGjrJzV16S5y4t7ICpfaAapNRrrUCv3cd5xIPKUqbbgKtx7CbVB+w+YRDMntoHwjuZ9ijI2AM8hMKISbvcw==}
     engines: {node: '>= 20'}
 
   inherits@2.0.4:
@@ -1289,40 +1289,40 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  impit-darwin-arm64@0.13.0:
+  impit-darwin-arm64@0.14.1:
     optional: true
 
-  impit-darwin-x64@0.13.0:
+  impit-darwin-x64@0.14.1:
     optional: true
 
-  impit-linux-arm64-gnu@0.13.0:
+  impit-linux-arm64-gnu@0.14.1:
     optional: true
 
-  impit-linux-arm64-musl@0.13.0:
+  impit-linux-arm64-musl@0.14.1:
     optional: true
 
-  impit-linux-x64-gnu@0.13.0:
+  impit-linux-x64-gnu@0.14.1:
     optional: true
 
-  impit-linux-x64-musl@0.13.0:
+  impit-linux-x64-musl@0.14.1:
     optional: true
 
-  impit-win32-arm64-msvc@0.13.0:
+  impit-win32-arm64-msvc@0.14.1:
     optional: true
 
-  impit-win32-x64-msvc@0.13.0:
+  impit-win32-x64-msvc@0.14.1:
     optional: true
 
-  impit@0.13.0:
+  impit@0.14.1:
     optionalDependencies:
-      impit-darwin-arm64: 0.13.0
-      impit-darwin-x64: 0.13.0
-      impit-linux-arm64-gnu: 0.13.0
-      impit-linux-arm64-musl: 0.13.0
-      impit-linux-x64-gnu: 0.13.0
-      impit-linux-x64-musl: 0.13.0
-      impit-win32-arm64-msvc: 0.13.0
-      impit-win32-x64-msvc: 0.13.0
+      impit-darwin-arm64: 0.14.1
+      impit-darwin-x64: 0.14.1
+      impit-linux-arm64-gnu: 0.14.1
+      impit-linux-arm64-musl: 0.14.1
+      impit-linux-x64-gnu: 0.14.1
+      impit-linux-x64-musl: 0.14.1
+      impit-win32-arm64-msvc: 0.14.1
+      impit-win32-x64-msvc: 0.14.1
 
   inherits@2.0.4: {}
 


### PR DESCRIPTION
Bumps the `impit` dependency to the latest version.
