### PR TITLE
feat: support CAMOUFOX_INSTALL_DIR to override the browser install directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ This is the JavaScript client for Camoufox. It is a port of the Python wrapper (
 npm install camoufox-js
 ```
 
+The Camoufox browser itself is downloaded with `npx camoufox-js fetch` into the
+per-user cache directory (`~/.cache/camoufox` on Linux). Set the
+`CAMOUFOX_INSTALL_DIR` environment variable to install and resolve it from a
+custom location instead — useful in containers and CI images where the home
+directory is ephemeral or persisted separately (similar to Playwright's
+`PLAYWRIGHT_BROWSERS_PATH`):
+
+```bash
+CAMOUFOX_INSTALL_DIR=/opt/camoufox npx camoufox-js fetch
+```
+
 ## Usage 
 
 You can launch Playwright-controlled Camoufox using this package like this:

--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -51,7 +51,15 @@ export const OS_NAME: "mac" | "win" | "lin" = OS_MAP[process.platform];
 const currentDir =
 	import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
-export const INSTALL_DIR: PathLike = userCacheDir("camoufox");
+/**
+ * Directory the Camoufox browser is downloaded to and launched from.
+ * Defaults to the per-user cache directory; set CAMOUFOX_INSTALL_DIR to
+ * relocate it (e.g. into a container image layer when the home directory
+ * is ephemeral or persisted separately).
+ */
+export const INSTALL_DIR: PathLike = process.env.CAMOUFOX_INSTALL_DIR
+	? path.resolve(process.env.CAMOUFOX_INSTALL_DIR)
+	: userCacheDir("camoufox");
 
 const formatBytes = (v: number, _: Options, type: string) =>
 	type === "total" || type === "value" ? prettyBytes(v) : String(v);

--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import type { PathLike } from "node:fs";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -307,7 +307,7 @@ export class CamoufoxFetcher extends GitHubDownloader {
 			this.setVersion();
 
 			if (OS_NAME !== "win") {
-				execSync(`chmod -R 755 ${INSTALL_DIR}`);
+				execFileSync("chmod", ["-R", "755", INSTALL_DIR.toString()]);
 			}
 
 			console.log("Camoufox successfully installed.");

--- a/test/pkgman.test.ts
+++ b/test/pkgman.test.ts
@@ -10,6 +10,7 @@ describe("INSTALL_DIR", () => {
 	});
 
 	test("defaults to the user cache dir", async () => {
+		vi.stubEnv("CAMOUFOX_INSTALL_DIR", "");
 		vi.resetModules();
 		const { INSTALL_DIR } = await import("../src/pkgman");
 		expect(INSTALL_DIR.toString()).toContain("camoufox");

--- a/test/pkgman.test.ts
+++ b/test/pkgman.test.ts
@@ -1,0 +1,26 @@
+import * as path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// INSTALL_DIR is a module-level constant, so each case re-imports the module
+// after adjusting the environment.
+describe("INSTALL_DIR", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	test("defaults to the user cache dir", async () => {
+		vi.resetModules();
+		const { INSTALL_DIR } = await import("../src/pkgman");
+		expect(INSTALL_DIR.toString()).toContain("camoufox");
+		expect(path.isAbsolute(INSTALL_DIR.toString())).toBe(true);
+	});
+
+	test("CAMOUFOX_INSTALL_DIR overrides the install location", async () => {
+		const target = path.join("custom", "camoufox-install");
+		vi.stubEnv("CAMOUFOX_INSTALL_DIR", target);
+		vi.resetModules();
+		const { INSTALL_DIR } = await import("../src/pkgman");
+		expect(INSTALL_DIR).toBe(path.resolve(target));
+	});
+});


### PR DESCRIPTION
Closes #286.

Adds a `CAMOUFOX_INSTALL_DIR` environment variable that overrides where the Camoufox browser is downloaded and resolved from. Defaults are unchanged; relative values are resolved to absolute paths.

Every consumer (fetch/extract, version checks, launch path resolution, `camoufox path`, GeoLite mmdb placement) already reads the single `INSTALL_DIR` constant, so the override covers the whole surface with one definition change.

## Changes

- `src/pkgman.ts` — read `CAMOUFOX_INSTALL_DIR` (resolved via `path.resolve`) before falling back to `userCacheDir("camoufox")`, plus a doc comment.
- `test/pkgman.test.ts` — covers the default and the override (module re-imported per case since the constant is evaluated at module init).
- `README.md` — documents the variable under Installation, with the container/CI motivation and the `PLAYWRIGHT_BROWSERS_PATH` analogy.

## Verification

```
$ node dist/__main__.js path
/Users/benn/Library/Caches/camoufox
$ CAMOUFOX_INSTALL_DIR=/opt/camoufox node dist/__main__.js path
/opt/camoufox
$ CAMOUFOX_INSTALL_DIR=relative/dir node dist/__main__.js path
/Users/benn/Documents/w/camoufox-js/relative/dir
```

`pnpm build` passes; `vitest run test/pkgman.test.ts` 2/2; `biome check` reports only the 5 warnings already present on master.

Motivation in detail: in container images the browser belongs in an image layer (e.g. `/opt/camoufox`) so it survives container recycling and stays out of home-directory backups — see #286.
