### PR TITLE
fix(virtdisplay): correct close-wrapper apply spread and missing return

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -316,12 +316,15 @@ async function _asyncAttachVD(
 		return browser;
 	}
 
-	const originalClose = browser.close;
+	const originalClose = browser.close.bind(browser);
 
 	browser.close = async (...args: any[]) => {
-		await originalClose.apply(browser, ...args);
-		if (virtualDisplay) {
-			virtualDisplay.kill();
+		try {
+			return await originalClose(...args);
+		} finally {
+			if (virtualDisplay) {
+				virtualDisplay.kill();
+			}
 		}
 	};
 
@@ -342,12 +345,15 @@ export function syncAttachVD(
 		return browser;
 	}
 
-	const originalClose = browser.close;
+	const originalClose = browser.close.bind(browser);
 
-	browser.close = (...args: any[]) => {
-		originalClose.apply(browser, ...args);
-		if (virtualDisplay) {
-			virtualDisplay.kill();
+	browser.close = async (...args: any[]) => {
+		try {
+			return await originalClose(...args);
+		} finally {
+			if (virtualDisplay) {
+				virtualDisplay.kill();
+			}
 		}
 	};
 


### PR DESCRIPTION
Both the async (_asyncAttachVD) and sync (syncAttachVD) browser.close
wrappers had two bugs:

1. `originalClose.apply(browser, ...args)` spreads the args array into
   apply's positional parameters, so apply receives (browser, arg0,
   arg1, ...) instead of (browser, argsArray). Should be
   `originalClose.apply(browser, args)`.
2. The async wrapper didn't return the original close()'s promise, so
   callers awaiting browser.close() resolved before teardown finished and
   .catch() handlers never saw close errors.

Bind originalClose to browser up front and fix both call sites.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>