### PR TITLE
fix(env): resolve bundle resources from executable_path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,28 @@ const CACHE_PREFS = {
 	"browser.cache.disk.smart_size.enabled": true,
 };
 
-function getEnvVars(configMap: ConfigMap, userAgentOS: string): EnvVars {
+function bundleResourcePath(file: string, executablePath?: string): string {
+	// Resolve a bundle resource (fontconfig/, properties.json, etc.) relative
+	// to the executable the caller actually launched, when one is provided.
+	// Mirrors getPath() but honors executable_path so a sandbox/alt-version
+	// build doesn't fall back to ~/.cache/camoufox/. Mac-bundle aware: when
+	// the executable lives in Camoufox.app/Contents/MacOS/, resources live
+	// in ../Resources/.
+	if (!executablePath) {
+		return getPath(file);
+	}
+	const dir = path.dirname(executablePath);
+	if (path.basename(dir) === "MacOS") {
+		return path.join(dir, "..", "Resources", file);
+	}
+	return path.join(dir, file);
+}
+
+function getEnvVars(
+	configMap: ConfigMap,
+	userAgentOS: string,
+	executablePath?: string,
+): EnvVars {
 	const envVars: EnvVars = {};
 	let updatedConfigData: Uint8Array;
 
@@ -71,7 +92,10 @@ function getEnvVars(configMap: ConfigMap, userAgentOS: string): EnvVars {
 	}
 
 	if (OS_NAME === "lin") {
-		const fontconfigPath = getPath(path.join("fontconfig", userAgentOS));
+		const fontconfigPath = bundleResourcePath(
+			path.join("fontconfig", userAgentOS),
+			executablePath,
+		);
 		envVars.FONTCONFIG_PATH = fontconfigPath;
 	}
 
@@ -94,14 +118,7 @@ interface Property {
 }
 
 function loadProperties(filePath?: PathLike): Record<string, string> {
-	let propFile: string;
-	filePath = filePath?.toString();
-	if (filePath) {
-		propFile = path.join(path.dirname(filePath), "properties.json");
-	} else {
-		propFile = getPath("properties.json");
-	}
-
+	const propFile = bundleResourcePath("properties.json", filePath?.toString());
 	const propData = readFileSync(propFile).toString();
 	const propDict: Property[] = JSON.parse(propData);
 
@@ -759,7 +776,7 @@ export async function launchOptions({
 
 	//Prepare environment variables to pass to Camoufox
 	const env_vars = {
-		...getEnvVars(config, targetOS),
+		...getEnvVars(config, targetOS, executable_path?.toString()),
 		...env,
 	};
 


### PR DESCRIPTION
Fontconfig dirs and properties.json were resolved relative to the
package's own install location, not the Camoufox executable the caller
actually launched via the executable_path launch option. When the two
differ (a custom/sandboxed Camoufox build), the wrapper pointed
FONTCONFIG_PATH and the properties loader at the wrong tree, so bundled
fonts and per-OS properties silently failed to load.

Add bundleResourcePath(file, executablePath) that resolves a bundle
resource relative to the launched executable when one is supplied, and
thread executable_path through getEnvVars() and the properties loader.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>