### PR TITLE
fix(virtdisplay): allocate Xvfb display by explicit number with retry

### DIFF
--- a/src/virtdisplay.ts
+++ b/src/virtdisplay.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { accessSync, constants as fsConstants } from "node:fs";
-import type { Readable } from "node:stream";
+import { randomInt } from "node:crypto";
+import { accessSync, constants as fsConstants, promises as fsP } from "node:fs";
 import {
 	CannotExecuteXvfb,
 	CannotFindXvfb,
@@ -8,8 +8,23 @@ import {
 } from "./exceptions.js";
 import { OS_NAME } from "./pkgman.js";
 
-// Safe timeout for xvfb writing display num, prevents infinite hang
-const DISPLAYFD_READ_TIMEOUT_MS = 10_000;
+// Per-spawn cap on how long we wait for an Xvfb to either win the .X{N}-lock
+// race or exit on collision. Xvfb fails its socket-bind in ~50ms on collision
+// and writes /tmp/.X{N}-lock in well under 1s on success — 10s is generous and
+// gives headroom under high apply-worker concurrency.
+const BIND_OR_EXIT_TIMEOUT_MS = 15_000;
+const MAX_DISPLAY_RETRIES = 5;
+
+// Display number is just an unsigned int; with -nolisten tcp there's no port
+// constraint, so we draw from a large sparse range. Birthday math: at 1000
+// concurrent spawns, collision probability is ~0.05% — retries cover the rest.
+// Lower bound stays clear of low displays commonly used by other X servers.
+const DISPLAY_MIN = 1000;
+const DISPLAY_MAX = 1_000_000_000;
+
+function pickDisplayNumber(): number {
+	return randomInt(DISPLAY_MIN, DISPLAY_MAX);
+}
 
 export class VirtualDisplay {
 	private debug: boolean;
@@ -68,12 +83,15 @@ export class VirtualDisplay {
 	}
 
 	/**
-	 * Launch Xvfb with -displayfd 3 so the kernel/Xvfb itself picks a free
-	 * display number atomically and reports it back to us. Avoids userspace race conditions
+	 * Spawn Xvfb with an explicit display number. Returns the child process.
+	 *
+	 * Avoids `-displayfd N`, which makes Xvfb walk display numbers from 0
+	 * upward and re-init GLX on every collision — the dominant cost under
+	 * concurrent bursts.
 	 */
-	private spawnXvfb(): ChildProcess {
+	private spawnOne(displayNum: number): ChildProcess {
 		const xvfbPath = this.xvfb_path;
-		const cmd = [xvfbPath, "-displayfd", "3", ...this.xvfb_args];
+		const cmd = [xvfbPath, `:${displayNum}`, ...this.xvfb_args];
 		if (this.debug) {
 			console.log("Starting virtual display:", cmd.join(" "));
 		}
@@ -83,7 +101,6 @@ export class VirtualDisplay {
 				"ignore",
 				this.debug ? "inherit" : "ignore",
 				this.debug ? "inherit" : "ignore",
-				"pipe", // fd 3 — Xvfb writes "<display>\n" here
 			],
 			detached: true,
 			env: {
@@ -94,41 +111,73 @@ export class VirtualDisplay {
 		});
 	}
 
+	/**
+	 * Did our spawned Xvfb win the kernel race for display N?
+	 *   - Our process exits → lost the race → caller should retry
+	 *   - /tmp/.X{N}-lock contains our PID → won → return true
+	 * The X{N}-lock O_CREAT|O_EXCL is the same atomic primitive Xvfb uses
+	 * with -displayfd, so race-safety is identical.
+	 */
+	private async waitForBindOrExit(
+		proc: ChildProcess,
+		displayNum: number,
+		timeoutMs: number,
+	): Promise<boolean> {
+		const lockPath = `/tmp/.X${displayNum}-lock`;
+		const startMs = Date.now();
+		while (Date.now() - startMs < timeoutMs) {
+			if (proc.exitCode !== null || proc.signalCode !== null) {
+				return false; // Xvfb exited — collision (or other failure)
+			}
+			try {
+				const content = await fsP.readFile(lockPath, "utf8");
+				const lockPid = Number.parseInt(content.trim(), 10);
+				if (Number.isFinite(lockPid) && lockPid === proc.pid) {
+					return true;
+				}
+			} catch {
+				// lock file not present yet, keep polling
+			}
+			await new Promise((r) => setTimeout(r, 5));
+		}
+		return false;
+	}
+
 	public async get(): Promise<string> {
 		VirtualDisplay.assert_linux();
 
 		if (!this.proc) {
-			this.proc = this.spawnXvfb();
-			const stream = this.proc.stdio[3] as Readable;
-			const timer = setTimeout(
-				() =>
-					stream.destroy(
-						new CannotExecuteXvfb(
-							`Xvfb did not report a display within ${DISPLAYFD_READ_TIMEOUT_MS}ms`,
-						),
-					),
-				DISPLAYFD_READ_TIMEOUT_MS,
-			);
-			let buf = "";
-			try {
-				for await (const chunk of stream) {
-					buf += chunk;
-					if (buf.includes("\n")) break;
-				}
-			} catch (err) {
-				this.kill();
-				throw err;
-			} finally {
-				clearTimeout(timer);
-			}
-			const n = Number.parseInt(buf, 10);
-			if (!Number.isFinite(n)) {
-				this.kill();
-				throw new CannotExecuteXvfb(
-					`Xvfb did not report a display (got ${JSON.stringify(buf)}, exit=${this.proc.exitCode})`,
+			let lastError: string | null = null;
+			for (let attempt = 0; attempt < MAX_DISPLAY_RETRIES; attempt++) {
+				const candidateN = pickDisplayNumber();
+				const proc = this.spawnOne(candidateN);
+				const won = await this.waitForBindOrExit(
+					proc,
+					candidateN,
+					BIND_OR_EXIT_TIMEOUT_MS,
 				);
+				if (won) {
+					this.proc = proc;
+					this._display = candidateN;
+					if (this.debug) {
+						console.log(
+							`Virtual display ready: :${candidateN} (attempts=${attempt + 1})`,
+						);
+					}
+					return `:${this._display}`;
+				}
+				lastError = `:${candidateN} collision or timeout (exit=${proc.exitCode}, signal=${proc.signalCode})`;
+				if (proc.exitCode === null && !proc.killed) {
+					try {
+						proc.kill("SIGKILL");
+					} catch {
+						/* ignore */
+					}
+				}
 			}
-			this._display = n;
+			throw new CannotExecuteXvfb(
+				`Failed to allocate a virtual display after ${MAX_DISPLAY_RETRIES} attempts. Last: ${lastError ?? "unknown"}`,
+			);
 		} else if (this.debug) {
 			console.log(`Using virtual display: ${this._display}`);
 		}
@@ -141,7 +190,11 @@ export class VirtualDisplay {
 			if (this.debug) {
 				console.log("Terminating virtual display:", this._display);
 			}
-			this.proc.kill();
+			try {
+				this.proc.kill("SIGKILL");
+			} catch {
+				/* ignore */
+			}
 		}
 	}
 

--- a/test/virtdisplay.test.ts
+++ b/test/virtdisplay.test.ts
@@ -5,8 +5,7 @@ import { VirtualDisplay } from "../src/virtdisplay";
 // VIRTDISPLAY_TEST_N controls the concurrent-launch count. Default is
 // kept low so the test passes on any developer box; set to 1000 (or
 // whatever) to exercise real scaling. At high N you will need
-// `ulimit -n` headroom — each Xvfb takes one X11 socket plus our
-// -displayfd pipe.
+// `ulimit -n` headroom — each Xvfb takes one X11 socket.
 const N = Number.parseInt(process.env.VIRTDISPLAY_TEST_N ?? "50", 10);
 
 // Track every VirtualDisplay we spawn so afterEach can guarantee
@@ -32,14 +31,29 @@ function killAllTracked(): void {
 // Reach into the private proc to inspect process liveness — needed to
 // assert kill() actually terminated Xvfb.
 function procOf(vd: VirtualDisplay) {
-	return (vd as unknown as { proc: { exitCode: number | null; pid?: number } })
-		.proc;
+	return (
+		vd as unknown as {
+			proc: {
+				exitCode: number | null;
+				signalCode: NodeJS.Signals | null;
+				pid?: number;
+			};
+		}
+	).proc;
+}
+
+// kill() sends SIGKILL, so a terminated Xvfb reports exitCode === null
+// and signalCode === "SIGKILL"; one that exited normally reports the
+// reverse. Either non-null value proves the process is gone.
+function hasExited(vd: VirtualDisplay): boolean {
+	const p = procOf(vd);
+	return p.exitCode !== null || p.signalCode !== null;
 }
 
 async function waitForExit(vd: VirtualDisplay, timeoutMs = 5_000) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		if (procOf(vd).exitCode !== null) return;
+		if (hasExited(vd)) return;
 		await sleep(25);
 	}
 }
@@ -53,12 +67,12 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 		const vd = track(new VirtualDisplay());
 		const display = await vd.get();
 		expect(display).toMatch(/^:\d+$/);
-		expect(procOf(vd).exitCode).toBeNull();
+		expect(hasExited(vd)).toBe(false);
 
 		vd.kill();
 		await waitForExit(vd);
 		tracked.delete(vd);
-		expect(procOf(vd).exitCode).not.toBeNull();
+		expect(hasExited(vd)).toBe(true);
 	}, 15_000);
 
 	test("get() is idempotent within one VirtualDisplay", async () => {
@@ -71,12 +85,11 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 	test(
 		`${N} concurrent reservations all get unique displays`,
 		async () => {
-			// Every VirtualDisplay spawns its own Xvfb. Each Xvfb scans up
-			// from :0 and atomically claims the first free X11 socket
-			// (kernel-mediated bind, no userspace race). -displayfd reports
-			// the chosen number back to us. A duplicate here would mean we
-			// mis-parsed or mis-routed the displayfd output, or two Xvfbs
-			// somehow bound the same socket.
+			// Every VirtualDisplay spawns its own Xvfb on a randomly chosen
+			// display number and confirms it won the /tmp/.X{N}-lock race
+			// (kernel-mediated O_CREAT|O_EXCL, no userspace race), retrying
+			// on collision. A duplicate here would mean two Xvfbs somehow
+			// believed they owned the same display number.
 			const vds = Array.from({ length: N }, () => track(new VirtualDisplay()));
 
 			const displays = await Promise.all(vds.map((vd) => vd.get()));
@@ -90,7 +103,7 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 
 			// Every Xvfb is alive.
 			for (const vd of vds) {
-				expect(procOf(vd).exitCode).toBeNull();
+				expect(hasExited(vd)).toBe(false);
 			}
 
 			// Tear them all down and confirm every Xvfb actually exited —
@@ -100,7 +113,7 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 			tracked.clear();
 
 			for (const vd of vds) {
-				expect(procOf(vd).exitCode).not.toBeNull();
+				expect(hasExited(vd)).toBe(true);
 			}
 		},
 		// Spawning thousands of Xvfb processes is genuinely slow.


### PR DESCRIPTION
### Problem

With `headless: "virtual"`, the display is acquired via `Xvfb -displayfd 3`, which makes Xvfb walk display numbers from 0 upward and **re-init GLX on every collision**. Under concurrent bursts (many `NewBrowser` calls at once) the collision-walk is the dominant startup cost.

Worse, the acquisition reads the chosen number off the fd-3 pipe with a `for await`. If Xvfb opens fd 3 but never writes a number — a half-init crash that doesn't close the pipe, a bind-retry loop, an exhausted ulimit — the read hangs forever and the child process leaks.

### Fix

Replace the `-displayfd` read with explicit allocation:

- Draw a display number from a large sparse range (`randomInt`), then spawn `Xvfb :N`.
- Decide who won the kernel race by reading `/tmp/.X{N}-lock`: our PID in the lock ⇒ we won; the child exiting ⇒ collision ⇒ retry. The `.X{N}-lock` file uses the same `O_CREAT | O_EXCL` atomic primitive Xvfb relies on with `-displayfd`, so race-safety is identical.
- Every attempt is bounded by a timeout and losing children are `SIGKILL`ed, so no path hangs or leaks a process. Retries (max 5) cover the rare birthday collision.

### Note on framebuffer size

The Xvfb framebuffer stays at **`1x1x24`**. The spoofed `screen.width`/`screen.height` come from the BrowserForge fingerprint, not the underlying X display, so the framebuffer size has no fingerprint impact and a 1×1 buffer keeps virtual-display memory minimal.

Net `+92 / -39` in `src/virtdisplay.ts`. Type-checks clean (`tsc --noEmit`), biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)