### PR TITLE
fix(pkgman): remove temp download dir after install

### DIFF
--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -293,12 +293,12 @@ export class CamoufoxFetcher extends GitHubDownloader {
 	async install(): Promise<void> {
 		await this.init();
 		await CamoufoxFetcher.cleanup();
+		// Set up outside the try so finally can always tear down the ~600MB staging dir.
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "camoufox-"));
+		const tempFilePath = path.join(tempDir, "camoufox.zip");
+		const tempFileStream = fs.createWriteStream(tempFilePath);
 		try {
 			fs.mkdirSync(INSTALL_DIR, { recursive: true });
-
-			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "camoufox-"));
-			const tempFilePath = path.join(tempDir, "camoufox.zip");
-			const tempFileStream = fs.createWriteStream(tempFilePath);
 
 			await webdl(this.url, "Downloading Camoufox...", true, tempFileStream);
 			await new Promise((r) => tempFileStream.close(r));
@@ -315,6 +315,19 @@ export class CamoufoxFetcher extends GitHubDownloader {
 			console.error(`Error installing Camoufox: ${e}`);
 			await CamoufoxFetcher.cleanup();
 			throw e;
+		} finally {
+			// Best-effort teardown: a throw here would mask the real result, and the caller is fire-and-forget.
+			try {
+				// Close before removing: Windows can't unlink a file with an open handle.
+				if (!tempFileStream.closed) {
+					await new Promise<void>((resolve) =>
+						tempFileStream.close(() => resolve()),
+					);
+				}
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			} catch (cleanupErr) {
+				console.error(`Failed to remove staging dir ${tempDir}: ${cleanupErr}`);
+			}
 		}
 	}
 

--- a/test/pkgman.test.ts
+++ b/test/pkgman.test.ts
@@ -1,5 +1,7 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 // INSTALL_DIR is a module-level constant, so each case re-imports the module
 // after adjusting the environment.
@@ -23,5 +25,91 @@ describe("INSTALL_DIR", () => {
 		vi.resetModules();
 		const { INSTALL_DIR } = await import("../src/pkgman");
 		expect(INSTALL_DIR).toBe(path.resolve(target));
+	});
+});
+
+// A fetch that writes a few bytes then errors mid-stream, like a dropped connection.
+function failingFetch() {
+	return vi.fn(async () => ({
+		ok: true,
+		headers: { get: () => "0" },
+		body: (async function* () {
+			yield new Uint8Array([1, 2, 3]);
+			throw new Error("connection reset");
+		})(),
+	}));
+}
+
+// A fetch that writes a few bytes and completes cleanly.
+function succeedingFetch() {
+	return vi.fn(async () => ({
+		ok: true,
+		headers: { get: () => "0" },
+		body: (async function* () {
+			yield new Uint8Array([1, 2, 3]);
+		})(),
+	}));
+}
+
+describe("CamoufoxFetcher.install cleanup", () => {
+	let tmp: string;
+	let installDir: string;
+
+	beforeEach(() => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cfx-pkgtest-"));
+		installDir = path.join(tmp, "install");
+		fs.mkdirSync(installDir);
+		// Isolate both the install location and the staging tmpdir into our own dir.
+		// os.tmpdir() reads TMPDIR on POSIX and TEMP/TMP on Windows - stub all three.
+		vi.stubEnv("CAMOUFOX_INSTALL_DIR", installDir);
+		vi.stubEnv("TMPDIR", tmp);
+		vi.stubEnv("TEMP", tmp);
+		vi.stubEnv("TMP", tmp);
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.resetModules();
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	// Staging dirs install() creates: <tmpdir>/camoufox-<6 random chars>.
+	function stagingDirs(): string[] {
+		return fs
+			.readdirSync(tmp)
+			.filter((n) => /^camoufox-[A-Za-z0-9]{6}$/.test(n));
+	}
+
+	async function installWith(fetchImpl: ReturnType<typeof vi.fn>) {
+		const { CamoufoxFetcher } = await import("../src/pkgman");
+		const fetcher = new CamoufoxFetcher();
+		// Skip the release lookup; just hand install() a URL to download.
+		vi.spyOn(fetcher, "init").mockImplementation(async () => {
+			(fetcher as unknown as { _url: string })._url =
+				"https://example.test/camoufox.zip";
+		});
+		// Don't extract the placeholder zip or write a version file.
+		vi.spyOn(fetcher, "extractZip").mockResolvedValue(undefined);
+		vi.spyOn(fetcher, "setVersion").mockImplementation(() => {});
+		vi.stubGlobal("fetch", fetchImpl);
+		vi.stubGlobal("console", { ...console, error: vi.fn(), log: vi.fn() });
+		return fetcher;
+	}
+
+	test("removes the staging dir when the download fails", async () => {
+		const fetcher = await installWith(failingFetch());
+		// The original download error must survive, and no staging dir is left.
+		await expect(fetcher.install()).rejects.toThrow("connection reset");
+		expect(stagingDirs()).toEqual([]);
+	});
+
+	test("removes the staging dir after a successful install", async () => {
+		const fetcher = await installWith(succeedingFetch());
+		// A successful install must resolve (not throw) and leave no staging dir.
+		await expect(fetcher.install()).resolves.toBeUndefined();
+		expect(stagingDirs()).toEqual([]);
 	});
 });


### PR DESCRIPTION
`install()` mkdtemps a staging dir, downloads the ~600MB zip into it, and never removes it. Every fetch leaks one, and an interrupted download strands a partial zip too. I hit 135 of these (~85GB) in `/tmp` on one box, enough to fill the disk.

Fix: create the staging dir before the `try`, close the write stream, then rm the dir in a `finally`, so it's cleaned on both the success and error paths. Closing before the unlink matters on Windows, which won't delete a file with an open handle (the same close-before-delete the success path already does).

The test runs a stubbed fetch that fails mid-stream (no network) and asserts no staging dir survives. It fails on the pre-fix code.

There are two sibling spots with the same "allocate then download without cleanup" shape (`addons.ts`, `locale.ts`), but the right fix for each is less clear-cut, so I've written them up separately in #301 rather than bundle them here.
