### PR TITLE
Fix Playwright 1.61+ compatibility: strip isMobile from viewport CDP calls

### DIFF
--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -64,5 +64,24 @@ export async function NewBrowser<
 	}
 
 	const browser = await playwright.launch(fromOptions);
+
+	// Fix: Strip isMobile from Browser.setDefaultViewport CDP call
+	// Playwright 1.61+ sends isMobile which Camoufox's Firefox doesn't recognize
+	// See https://github.com/apify/camoufox-js/issues/299
+	if (browser && (browser as any)._connection) {
+		const conn = (browser as any)._connection;
+		const origSend = conn.sendMessageToServer.bind(conn);
+		conn.sendMessageToServer = async (msg: string) => {
+			try {
+				const parsed = JSON.parse(msg);
+				if (parsed.method === "Browser.setDefaultViewport" && parsed.params?.viewport?.isMobile !== undefined) {
+					const { isMobile, ...cleanViewport } = parsed.params.viewport;
+					parsed.params.viewport = cleanViewport;
+					return origSend(JSON.stringify(parsed));
+				}
+			} catch {}
+			return origSend(msg);
+		};
+	}
 	return syncAttachVD(browser, virtualDisplay);
 }


### PR DESCRIPTION
## Description

Playwright 1.61 added `isMobile` to the `Browser.setDefaultViewport` CDP command (see [PR #41179](https://github.com/microsoft/playwright/pull/41179)), which Camoufox's custom Firefox build does not recognize. This causes `browser.newPage()` and `browser.newContext()` to fail with:

```
Found property "<root>.viewport.isMobile" - false which is not described in this scheme
```

## Fix

Intercepts CDP messages at the browser connection level and strips `isMobile` from `Browser.setDefaultViewport` calls before they reach the Firefox binary.

Verified working against Playwright 1.61 across multiple Cloudflare-protected sites.

Fixes #299