### PR TITLE
fix: clean up empty addon directory on download failure

### DIFF
--- a/src/addons.ts
+++ b/src/addons.ts
@@ -91,6 +91,11 @@ export async function maybeDownloadAddons(
 			addonsList.push(addonPath);
 		} catch (e) {
 			console.error(`Failed to download and extract ${addonName}: ${e}`);
+			// Clean up the empty directory created before the download attempt.
+			// Without this, the next retry sees the directory and treats it as
+			// a successfully downloaded addon, then crashes with "manifest.json
+			// is missing" in confirmPaths.
+			fs.rmSync(addonPath, { recursive: true, force: true });
 		}
 	}
 }


### PR DESCRIPTION
## Summary

When `maybeDownloadAddons` fails to download an addon (e.g., network timeout), the empty directory created by `mkdirSync` before the download attempt is left behind. On the next retry — either via background warm or subsequent `launchOptions` call — `fs.existsSync` sees the directory and treats it as a successfully downloaded addon. The empty path is then passed to `confirmPaths`, which throws `manifest.json is missing` and crashes the browser launch.

## Root Cause

`maybeDownloadAddons` in `src/addons.ts` creates the addon directory with `mkdirSync` \*before\* attempting the download:

```ts
try {
    fs.mkdirSync(addonPath, { recursive: true });  // ← directory created
    await downloadAndExtract(...);                   // ← fails
    addonsList.push(addonPath);
} catch (e) {
    console.error(...);  // ← directory NOT cleaned up
}
```

## Fix

Clean up the empty directory in the catch block so that retries re-download properly instead of crashing:

```ts
} catch (e) {
    console.error(`Failed to download and extract ${addonName}: ${e}`);
    fs.rmSync(addonPath, { recursive: true, force: true });
}
```

## Reproduction

1. Set up a slow or unreliable network (or proxy environment) where the addon download times out
2. Call `launchOptions()` — first attempt fails, empty directory created
3. Background warm retry: `fs.existsSync` returns `true` → skips download → passes empty path
4. `confirmPaths` → `manifest.json is missing` → crash

## Testing

- [ ] Addon download succeeds: behavior unchanged
- [ ] Addon download fails: directory is cleaned up, next retry re-downloads properly
- [ ] No regression for `excludeList` path (which skips download entirely)