### PR TITLE
chore(test): correct locale assertion for `Intl.DateTimeFormat`

### DIFF
--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -254,7 +254,11 @@ describe("Fingerprint injection", () => {
 		const locale = await page.evaluate(
 			() => Intl.DateTimeFormat().resolvedOptions().locale,
 		);
-		expect(locale).toBe("fr-FR");
+		// Per ECMA-402 ResolveLocale, a requested locale is matched against the
+		// engine's available locales via lookup/best-fit and may be resolved to a
+		// shorter prefix (e.g. "fr" instead of "fr-FR") when the fully-specified
+		// tag isn't itself in that list, so the region subtag isn't guaranteed here.
+		expect(locale).toMatch(/^fr/);
 
 		const language = await page.evaluate(() => navigator.language);
 		expect(language).toMatch(/^fr/);


### PR DESCRIPTION
Newer Firefox releases resolve Intl.DateTimeFormat().resolvedOptions().locale to "fr" rather than "fr-FR" for a requested fr-FR locale, which is valid per ECMA-402's lookup/best-fit locale matching. The test now asserts the language prefix instead of the exact region-qualified tag.