### PR TITLE
fix: cap playwright-core to <1.61.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
 		"@types/language-tags": "^1.0.4",
 		"@types/node": "^24.0.0",
 		"@types/xml2js": "^0.4.14",
-		"playwright-core": "^1.53.1",
+		"playwright-core": "<1.61.0",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3",
 		"vitest": "^4.0.0"
 	},
 	"peerDependencies": {
-		"playwright-core": "*"
+		"playwright-core": "<1.61.0"
 	},
 	"devEngines": {
 		"packageManager": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         specifier: ^0.4.14
         version: 0.4.14
       playwright-core:
-        specifier: ^1.53.1
+        specifier: <1.61.0
         version: 1.59.1
       rimraf:
         specifier: ^6.0.1


### PR DESCRIPTION
Playwright 1.61 sends `isMobile` in the `Browser.setDefaultViewport` CDP call, which Camoufox's bundled Firefox scheme doesn't recognize, so `newPage()`/`newContext()` fail with:

```
Found property "<root>.viewport.isMobile" - false which is not described in this scheme
```

Root cause is Camoufox's Firefox build not having `isMobile` in its Juggler protocol scheme yet. Until that's added upstream, pin `playwright-core` below 1.61, same as the Python lib did (daijro/camoufox#653, fix in daijro/camoufox PR https://github.com/daijro/camoufox/commit/195298d).

Closes #302
Fixes #299