### PR TITLE
fix(stealth): only seed fingerprint properties the installed browser supports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,10 +124,8 @@ interface EnvVars {
 
 function validateConfig(
 	configMap: Record<string, string>,
-	path?: PathLike,
+	propertyTypes: Record<string, string>,
 ): void {
-	const propertyTypes = loadProperties(path);
-
 	for (const [key, value] of Object.entries(configMap)) {
 		const expectedType = propertyTypes[key];
 		if (!expectedType) {
@@ -628,12 +626,17 @@ export async function launchOptions({
 	// a per-launch audio:seed the AudioFingerprintManager defaults to 0, so every
 	// spoofed context returns identical audio samples — a "same machine behind
 	// many identities" tell on CreepJS. setInto is "set only if unset", so a
-	// caller-supplied seed wins (the JS equivalent of setdefault).
+	// caller-supplied seed wins (the JS equivalent of setdefault). audio:seed and
+	// canvas:seed only exist since Camoufox 2.0, and the library supports older
+	// builds, so seed only what the installed browser's schema knows.
 	const randint = (min: number, max: number) =>
 		Math.floor(Math.random() * (max - min + 1)) + min;
-	setInto(config, "fonts:spacing_seed", randint(1, 4_294_967_295));
-	setInto(config, "audio:seed", randint(1, 4_294_967_295));
-	setInto(config, "canvas:seed", randint(1, 4_294_967_295));
+	const knownProperties = loadProperties(executable_path);
+	for (const seed of ["fonts:spacing_seed", "audio:seed", "canvas:seed"]) {
+		if (seed in knownProperties) {
+			setInto(config, seed, randint(1, 4_294_967_295));
+		}
+	}
 
 	const targetOS = getTargetOS(config);
 
@@ -767,7 +770,7 @@ export async function launchOptions({
 	}
 
 	// Validate the config
-	validateConfig(config, executable_path);
+	validateConfig(config, knownProperties);
 
 	//Prepare environment variables to pass to Camoufox
 	const env_vars = {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,9 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { getAsBooleanFromENV } from "../src/utils";
+import { getPath } from "../src/pkgman";
+import { getAsBooleanFromENV, launchOptions } from "../src/utils";
 
 describe("getAsBooleanFromENV", () => {
 	afterEach(() => {
@@ -34,5 +38,65 @@ describe("getAsBooleanFromENV", () => {
 
 	test("returns false when env var not set and no default", () => {
 		expect(getAsBooleanFromENV("TEST_BOOL_VAR")).toBe(false);
+	});
+});
+
+describe("launchOptions seeding", () => {
+	const readConfig = (env: Record<string, unknown>) =>
+		JSON.parse(
+			Object.keys(env)
+				.filter((k) => k.startsWith("CAMOU_CONFIG_"))
+				.sort()
+				.map((k) => env[k])
+				.join(""),
+		);
+
+	// Browsers older than Camoufox 2.0 have no audio:seed / canvas:seed property,
+	// and validateConfig rejects anything missing from properties.json.
+	const legacyBrowserDir = () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "camoufox-legacy-"));
+		const properties = JSON.parse(
+			fs.readFileSync(getPath("properties.json"), "utf-8"),
+		).filter(
+			(p: { property: string }) =>
+				p.property !== "audio:seed" && p.property !== "canvas:seed",
+		);
+		fs.writeFileSync(
+			path.join(dir, "properties.json"),
+			JSON.stringify(properties),
+		);
+		return path.join(dir, "camoufox-bin");
+	};
+
+	test("seeds all three properties on a supported browser", async () => {
+		const { env } = await launchOptions({ headless: true });
+		expect(Object.keys(readConfig(env))).toEqual(
+			expect.arrayContaining([
+				"fonts:spacing_seed",
+				"audio:seed",
+				"canvas:seed",
+			]),
+		);
+	});
+
+	test("skips seeds the installed browser does not support", async () => {
+		const { env } = await launchOptions({
+			headless: true,
+			executable_path: legacyBrowserDir(),
+		});
+		const keys = Object.keys(readConfig(env));
+		expect(keys).toContain("fonts:spacing_seed");
+		expect(keys).not.toContain("audio:seed");
+		expect(keys).not.toContain("canvas:seed");
+	});
+
+	test("still rejects an explicitly passed unsupported seed", async () => {
+		await expect(
+			launchOptions({
+				headless: true,
+				executable_path: legacyBrowserDir(),
+				config: { "audio:seed": 123 },
+			}),
+		).rejects.toThrow("Unknown property audio:seed in config");
 	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -68,6 +68,18 @@ describe("launchOptions seeding", () => {
 		return path.join(dir, "camoufox-bin");
 	};
 
+	// Skipping an unsupported seed is silent, so if a seed were ever renamed
+	// upstream we would quietly stop seeding it. Pin the names against the
+	// installed browser's schema so that shows up as a failure instead.
+	test("the installed browser declares every seed we set", () => {
+		const properties: { property: string; type: string }[] = JSON.parse(
+			fs.readFileSync(getPath("properties.json"), "utf-8"),
+		);
+		for (const seed of ["fonts:spacing_seed", "audio:seed", "canvas:seed"]) {
+			expect(properties).toContainEqual({ property: seed, type: "uint" });
+		}
+	});
+
 	test("seeds all three properties on a supported browser", async () => {
 		const { env } = await launchOptions({ headless: true });
 		expect(Object.keys(readConfig(env))).toEqual(


### PR DESCRIPTION
`audio:seed` and `canvas:seed` were introduced upstream in Camoufox 2.0 (`daijro/camoufox@c6a6c20`), but the library's supported browser range is `>=alpha.1, <1` — every build. On a pre-2.0 install the shipped `properties.json` has neither key, so #288's unconditional seeding made `validateConfig` throw `UnknownProperty` on a key the library itself had just set, breaking every `launch()`. Seeding is now gated on the installed browser's schema; an explicitly caller-supplied unsupported seed still errors as before.

Reproduced against a pre-2.0 `properties.json` (`135.0.1-beta.24`), which fails on `master` and passes here. Note that the issue's claim about `152.0.4-beta.26` doesn't hold — the browser ships `settings/properties.json` verbatim and that file has had both keys since 2.0, so a current install works on `master` too (verified against `152.0.4-beta.28`); the reporter most likely had a stale install directory.

Closes #307.