### PR TITLE
fix: page reports spoofed window size instead of 1280x720

### DIFF
--- a/src/sync_api.ts
+++ b/src/sync_api.ts
@@ -5,7 +5,13 @@ import {
 	firefox,
 } from "playwright-core";
 
-import { type LaunchOptions, launchOptions, syncAttachVD } from "./utils.js";
+import {
+	attachNoViewportDefault,
+	type LaunchOptions,
+	launchOptions,
+	spoofsWindowDimensions,
+	syncAttachVD,
+} from "./utils.js";
 import { VirtualDisplay } from "./virtdisplay.js";
 
 export async function Camoufox<
@@ -55,7 +61,12 @@ export async function NewBrowser<
 		});
 	}
 
+	const noViewportDefault = spoofsWindowDimensions(fromOptions);
+
 	if (typeof userDataDir === "string") {
+		if (noViewportDefault && !("viewport" in fromOptions)) {
+			fromOptions = { ...fromOptions, viewport: null };
+		}
 		const context = await playwright.launchPersistentContext(
 			userDataDir,
 			fromOptions,
@@ -64,5 +75,8 @@ export async function NewBrowser<
 	}
 
 	const browser = await playwright.launch(fromOptions);
+	if (noViewportDefault) {
+		attachNoViewportDefault(browser);
+	}
 	return syncAttachVD(browser, virtualDisplay);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -308,6 +308,65 @@ function warnManualConfig(config: Record<string, any>): void {
 	}
 }
 
+const WINDOW_DIM_KEYS = [
+	"window.outerWidth",
+	"window.outerHeight",
+	"window.innerWidth",
+	"window.innerHeight",
+	"document.body.clientWidth",
+	"document.body.clientHeight",
+];
+
+/**
+ * Whether the CAMOU_CONFIG in a set of launch options spoofs any window
+ * dimension. The config is chunked across CAMOU_CONFIG_<n> env vars, so
+ * reassemble it in index order before looking.
+ */
+export function spoofsWindowDimensions(
+	fromOptions: Record<string, any>,
+): boolean {
+	const env: Record<string, string> = fromOptions.env ?? {};
+	const chunks = Object.entries(env)
+		.filter(([key]) => key.startsWith("CAMOU_CONFIG_"))
+		.map(([key, value]) => [Number(key.split("_").pop()), value] as const)
+		.sort(([a], [b]) => a - b);
+	if (chunks.length === 0) {
+		return false;
+	}
+	const blob = chunks.map(([, value]) => value).join("");
+	return WINDOW_DIM_KEYS.some((key) => blob.includes(key));
+}
+
+/**
+ * Defaults newPage()/newContext() to `viewport: null`.
+ *
+ * Playwright applies a 1280x720 viewport by default, which makes Juggler ask
+ * the content window to become 1280x720. When Camoufox is pinning the window to
+ * a spoofed size, that request can never be satisfied, so the page reports the
+ * Playwright viewport instead of the spoofed dimensions (and a second
+ * newPage() can hang - daijro/camoufox#666).
+ *
+ * Without a viewport, Juggler measures the window instead of resizing it.
+ * An explicit viewport from the caller always wins.
+ */
+export function attachNoViewportDefault<T>(target: T): T {
+	for (const name of ["newPage", "newContext"] as const) {
+		const original = (target as any)[name];
+		if (typeof original !== "function") {
+			continue;
+		}
+		(target as any)[name] = (options?: Record<string, any>, ...rest: any[]) =>
+			original.call(
+				target,
+				options && "viewport" in options
+					? options
+					: { ...options, viewport: null },
+				...rest,
+			);
+	}
+	return target;
+}
+
 async function _asyncAttachVD(
 	browser: any,
 	virtualDisplay?: VirtualDisplay,

--- a/test/viewport.test.ts
+++ b/test/viewport.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { Camoufox } from "../src";
+import { attachNoViewportDefault, spoofsWindowDimensions } from "../src/utils";
+
+describe("spoofsWindowDimensions", () => {
+	test("detects a spoofed dimension across config chunks", () => {
+		expect(
+			spoofsWindowDimensions({
+				env: {
+					CAMOU_CONFIG_2: 'erWidth":1280}',
+					CAMOU_CONFIG_1: '{"window.out',
+				},
+			}),
+		).toBe(true);
+	});
+
+	test("is false without window dimensions in the config", () => {
+		expect(
+			spoofsWindowDimensions({
+				env: { CAMOU_CONFIG_1: '{"navigator.platform":"Win32"}' },
+			}),
+		).toBe(false);
+	});
+
+	test("is false without a config", () => {
+		expect(spoofsWindowDimensions({})).toBe(false);
+	});
+});
+
+describe("attachNoViewportDefault", () => {
+	const stub = () => {
+		const calls: any[] = [];
+		return {
+			calls,
+			newPage: (options?: any) => calls.push(options),
+			newContext: (options?: any) => calls.push(options),
+		};
+	};
+
+	test("defaults newPage/newContext to no viewport", () => {
+		const target = attachNoViewportDefault(stub());
+		target.newPage();
+		target.newContext({ locale: "en-US" });
+		expect(target.calls).toEqual([
+			{ viewport: null },
+			{ locale: "en-US", viewport: null },
+		]);
+	});
+
+	test("keeps an explicit viewport", () => {
+		const target = attachNoViewportDefault(stub());
+		target.newPage({ viewport: { width: 800, height: 600 } });
+		expect(target.calls).toEqual([{ viewport: { width: 800, height: 600 } }]);
+	});
+});
+
+describe("window size", () => {
+	test("page reports the spoofed window size, not Playwright's default", async () => {
+		const browser = await Camoufox({
+			os: "windows",
+			headless: true,
+			window: [1650, 1080],
+		});
+
+		try {
+			const page = await browser.newPage();
+			const size = await page.evaluate(() => ({
+				width: window.innerWidth,
+				height: window.innerHeight,
+			}));
+			expect(size.width).toBe(1650);
+			expect(size.height).toBeLessThanOrEqual(1080);
+			expect(size).not.toEqual({ width: 1280, height: 720 });
+		} finally {
+			await browser.close();
+		}
+	}, 30e3);
+});


### PR DESCRIPTION
Playwright applies a default 1280x720 viewport on `newPage()`/`newContext()`, which makes Juggler resize the content window and override the window dimensions Camoufox pinned, so pages reported 1280x720 regardless of the `screen`/`window` options. When the config spoofs window dimensions we now default to no viewport (an explicit `viewport` still wins), which is what the Python lib does since [daijro/camoufox#673](https://github.com/daijro/camoufox/pull/673). 

Closes #308.