### PR TITLE
fix(pkgman): preserve entry paths when extracting archives

### DIFF
--- a/src/pkgman.ts
+++ b/src/pkgman.ts
@@ -511,7 +511,7 @@ export async function unzip(
 		if (bar) {
 			console.log(`Extracting ${entry.entryName}`);
 		}
-		zip.extractEntryTo(entry, extractPath, false, true);
+		zip.extractEntryTo(entry, extractPath, true, true);
 	}
 
 	if (bar) {


### PR DESCRIPTION
`unzip()` passed `maintainEntryPath=false` to `extractEntryTo`, flattening the archive so the uBlock Origin xpi was extracted with its nested directories collapsed and duplicate basenames overwriting each other. Verified against the real xpi: all 655 entries now land at their original paths, including all 72 `_locales/*/messages.json` files. Closes #305