### PR TITLE
fix(cli): await GeoIP and addon downloads in fetch command

### DIFF
--- a/src/__main__.ts
+++ b/src/__main__.ts
@@ -89,9 +89,9 @@ program.command("fetch").action(async () => {
 	const updater = await CamoufoxUpdate.create();
 	await updater.update();
 	if (ALLOW_GEOIP) {
-		downloadMMDB();
+		await downloadMMDB();
 	}
-	maybeDownloadAddons(DefaultAddons);
+	await maybeDownloadAddons(DefaultAddons);
 });
 
 program.command("remove").action(async () => {


### PR DESCRIPTION
The `fetch` action started `downloadMMDB()` and `maybeDownloadAddons()` without awaiting them, so both ran concurrently after the action had already returned. Their progress output interleaved on stdout, and a failure in one aborted the other mid-write because the unhandled rejection tears the process down immediately. Adding the awaits makes the two downloads run in sequence and complete before the action resolves.

Closes #278