### PR TITLE
fix(virtdisplay): remove Xvfb socket/lock file on kill(), matching daijro/camoufox#652

### DIFF
--- a/src/virtdisplay.ts
+++ b/src/virtdisplay.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { accessSync, constants as fsConstants } from "node:fs";
+import { accessSync, constants as fsConstants, unlinkSync } from "node:fs";
 import type { Readable } from "node:stream";
 import {
 	CannotExecuteXvfb,
@@ -137,12 +137,25 @@ export class VirtualDisplay {
 	}
 
 	public kill(): void {
-		if (this.proc && this.proc.exitCode === null && !this.proc.killed) {
-			if (this.debug) {
-				console.log("Terminating virtual display:", this._display);
-			}
-			this.proc.kill();
+		const proc = this.proc;
+		const display = this._display;
+		if (!proc || proc.exitCode !== null || proc.killed) return;
+		if (this.debug) {
+			console.log("Terminating virtual display:", display);
 		}
+		proc.once("exit", () => {
+			try {
+				unlinkSync(`/tmp/.X${display}-lock`);
+			} catch {
+				// already gone
+			}
+			try {
+				unlinkSync(`/tmp/.X11-unix/X${display}`);
+			} catch {
+				// already gone
+			}
+		});
+		proc.kill("SIGKILL");
 	}
 
 	private static assert_linux(): void {

--- a/test/virtdisplay.test.ts
+++ b/test/virtdisplay.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, describe, expect, test } from "vitest";
 import { VirtualDisplay } from "../src/virtdisplay";
@@ -32,14 +33,31 @@ function killAllTracked(): void {
 // Reach into the private proc to inspect process liveness — needed to
 // assert kill() actually terminated Xvfb.
 function procOf(vd: VirtualDisplay) {
-	return (vd as unknown as { proc: { exitCode: number | null; pid?: number } })
-		.proc;
+	return (
+		vd as unknown as {
+			proc: {
+				exitCode: number | null;
+				signalCode: string | null;
+				pid?: number;
+			};
+		}
+	).proc;
+}
+
+// kill() sends SIGKILL, which is uncatchable -- Xvfb never gets to call its
+// own exit(), so Node reports signalCode, not a numeric exitCode. Either one
+// being set means the process has exited.
+function hasExited(proc: {
+	exitCode: number | null;
+	signalCode: string | null;
+}) {
+	return proc.exitCode !== null || proc.signalCode !== null;
 }
 
 async function waitForExit(vd: VirtualDisplay, timeoutMs = 5_000) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		if (procOf(vd).exitCode !== null) return;
+		if (hasExited(procOf(vd))) return;
 		await sleep(25);
 	}
 }
@@ -58,7 +76,7 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 		vd.kill();
 		await waitForExit(vd);
 		tracked.delete(vd);
-		expect(procOf(vd).exitCode).not.toBeNull();
+		expect(hasExited(procOf(vd))).toBe(true);
 	}, 15_000);
 
 	test("get() is idempotent within one VirtualDisplay", async () => {
@@ -100,12 +118,28 @@ describe.skipIf(process.platform !== "linux")("VirtualDisplay", () => {
 			tracked.clear();
 
 			for (const vd of vds) {
-				expect(procOf(vd).exitCode).not.toBeNull();
+				expect(hasExited(procOf(vd))).toBe(true);
 			}
 		},
 		// Spawning thousands of Xvfb processes is genuinely slow.
 		Math.max(5_000, N * 200),
 	);
+
+	test("kill() removes the X11 socket and lock file", async () => {
+		const vd = track(new VirtualDisplay());
+		const display = await vd.get();
+		const n = display.slice(1);
+		const socketPath = `/tmp/.X11-unix/X${n}`;
+		const lockPath = `/tmp/.X${n}-lock`;
+		expect(existsSync(socketPath)).toBe(true);
+
+		vd.kill();
+		await waitForExit(vd);
+		tracked.delete(vd);
+
+		expect(existsSync(socketPath)).toBe(false);
+		expect(existsSync(lockPath)).toBe(false);
+	}, 15_000);
 
 	test("released display numbers can be reused on the next launch", async () => {
 		const a = track(new VirtualDisplay());


### PR DESCRIPTION
Closes #322

## Summary

`VirtualDisplay.kill()` only called `this.proc.kill()` (SIGTERM). Nothing removed the Xvfb socket (`/tmp/.X11-unix/X<n>`) or lock file (`/tmp/.X<n>-lock`) it created. Under real-world restart churn these accumulate with no cap.

This is exactly what [daijro/camoufox#652](https://github.com/daijro/camoufox/pull/652) fixed upstream: switched to SIGKILL and explicitly unlinks both files. This port never picked that fix up; `src/virtdisplay.ts`'s `kill()` is still the pre-#652 shape even after #164/#168's `-displayfd` rewrite. This PR ports #652.

Hit this via [camofox-browser](https://github.com/jo-inc/camofox-browser), an HTTP wrapper around this package, which restarts the browser periodically under normal operation. [jo-inc/camofox-browser#9252](https://github.com/jo-inc/camofox-browser/pull/9252) is a compensating workaround shipped there in the meantime.

## Why SIGKILL, not just adding cleanup after the existing SIGTERM

SIGTERM is catchable, so Xvfb can run its own signal handler and clean up its own socket/lock file, which (per my testing below) it apparently does reliably in a simple, idle, single-instance scenario. SIGKILL is not catchable, so switching to it guarantees Xvfb never gets a chance to run its own cleanup, making our explicit cleanup the only thing removing these files, deterministically. It's not dependent on Xvfb's graceful-shutdown path succeeding, which per #652's reporter's testimony and the downstream leak I hit, doesn't always happen under real load.

## What I left out of the port

Python's #652 also does `self.proc = None` after cleanup. I didn't port that: `get()` here only respawns Xvfb when `!this.proc`, so nulling it changes the observable behavior of calling `get()` again after `kill()` on the same instance. That's a separate concern from the file-cleanup bug this PR is about, and the existing test suite's helpers (`procOf`) read `vd.proc` after `kill()` expecting it to still reference the (now-exited) process, not `null`. Happy to open that as a separate discussion if it's actually wanted, just didn't want to bundle an unrelated behavior change into this fix.

## Test changes

Switching to SIGKILL changes what Node reports on the killed process: SIGKILL bypasses Xvfb's own `exit()` call entirely, so Node sets `signalCode` instead of a numeric `exitCode`. The two existing "kill terminates Xvfb" assertions in `virtdisplay.test.ts` checked `exitCode` specifically and would now fail (well, actually hang for the full 5s `waitForExit` timeout, then fail) against an Xvfb that *did* exit correctly, just via signal rather than a clean `exit()` call. Updated `waitForExit` and those two assertions to check either field via a small `hasExited()` helper.

Added a new test asserting the socket and lock file are both gone after `kill()` and confirmed exit.

**Being upfront about a limitation of that test:** it doesn't cleanly fail against the unpatched code in this environment. I reverted just the `src/virtdisplay.ts` change and reran. All 5 tests still passed, including the new one, because Xvfb apparently cleans up its own socket/lock file fine under a plain SIGTERM in a quick, idle, single-Xvfb test. So this specific test can't prove the old code was broken here, it can only regression-guard the new code's contract going forward. That matches #652's own history too: no automated test in that PR either, accepted on the reporter's testimony of eliminating "zombie Xvfb processes" under heavy load over months of production use, not a synthetic repro. I don't have a cleaner reproduction than that to offer.

## Testing

\`\`\`
$ npx vitest run
Test Files  6 passed (6)
     Tests  51 passed (51)

$ npx tsc --noEmit
(clean)

$ npx biome check src/virtdisplay.ts test/virtdisplay.test.ts
(clean, after --write for formatting)
\`\`\`