### PR TITLE
feat: use geoip string as IP directly, skip publicIP lookup

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -729,8 +729,10 @@ export async function launchOptions({
 	if (geoip) {
 		geoipAllowed();
 
-		// Find the user's IP address
-		geoip = await publicIP(proxyUrl?.href);
+		// Use provided IP directly, or resolve the public IP via the proxy if provided
+		if (typeof geoip !== "string") {
+			geoip = await publicIP(proxyUrl?.href);
+		}
 
 		// Spoof WebRTC if not blocked
 		if (!block_webrtc) {


### PR DESCRIPTION
The geoip option already accepts `string | boolean` in the TypeScript type definition (matching the Python API), but the implementation always called `publicIP()` to resolve the address — ignoring any string value passed by the caller.

Changes:
- If geoip is a valid IP string, it is used directly for geolocation lookup — no outbound request is made to resolve the public IP
- If geoip is true, behavior is unchanged: the public IP is resolved automatically (via the proxy if one is set)
- Invalid IP strings are caught by the existing validateIP call inside getGeolocation

This brings the JS implementation in line with the Python version's documented behavior:
`Pass the target IP address to use, or true to find the IP address automatically.`