### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v6
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     fetch-depth: 0
 
             -   name: Set up Node.js
-                uses: actions/setup-node@v6
+                uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
                 with:
                     node-version: '24'
                     package-manager-cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
                 node-version: [22, 24, 26]
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
             - name: Set up Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
               with:
                   node-version: ${{ matrix.node-version }}
                   package-manager-cache: false

--- a/.github/workflows/update-new-issue.yml
+++ b/.github/workflows/update-new-issue.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             # Add the "t-tooling" label to all new issues
-            - uses: actions/github-script@v8
+            - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       github.rest.issues.addLabels({


### PR DESCRIPTION
This pins every third-party action in the workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

Same change as apify/crawlee#4051, rolled out team-wide. The trigger was the `v11` tag of `EndBug/add-and-commit` moving to a broken release that failed to load and killed the crawlee publish workflow. With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. Where `EndBug/add-and-commit` is used, it's pinned to v11.0.0, the last working release.

Own-org references (`apify/*`) stay on floating refs on purpose, since we control those repos.
