### PR TITLE
fix(webgl): stop the weighted draw from sampling software renderers

### DIFF
--- a/src/webgl/sample.ts
+++ b/src/webgl/sample.ts
@@ -61,7 +61,13 @@ export async function sampleWebGL(
 		query = `SELECT vendor, renderer, data, ${os} FROM webgl_fingerprints WHERE vendor = ? AND renderer = ?`;
 		params = [vendor, renderer];
 	} else {
-		query = `SELECT vendor, renderer, data, ${os} FROM webgl_fingerprints WHERE ${os} > 0`;
+		// Software rasterizers must never win the weighted draw. WAFs flag
+		// them far more reliably than any GPU/screen mismatch (see
+		// daijro/camoufox#743, which fixed the same bias in the python
+		// generator, and #276's dataset analysis). An explicit
+		// vendor/renderer pair below still selects them on purpose -- this
+		// only stops the random sampler from handing them out.
+		query = `SELECT vendor, renderer, data, ${os} FROM webgl_fingerprints WHERE ${os} > 0 AND renderer NOT LIKE '%llvmpipe%' AND renderer NOT LIKE '%SwiftShader%' AND renderer NOT LIKE '%Basic Render%' AND renderer NOT LIKE '%Generic Renderer%'`;
 	}
 
 	return new Promise<WebGLData>((resolve, reject) => {

--- a/test/webgl-software-renderers.test.ts
+++ b/test/webgl-software-renderers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { getPossiblePairs, sampleWebGL } from "../src/webgl/sample";
+
+// Software rasterizers are legitimate dataset rows (the db is built from real
+// user submissions) but must never win the weighted draw: pages can read the
+// renderer string and a GPU-less software renderer is one of the strongest
+// "this is a bot" signals there is. daijro/camoufox#743 applied the same rule
+// to the python generator; #276 documents the dataset contamination.
+
+const SOFTWARE_RENDERER_PATTERNS = [
+	/llvmpipe/i,
+	/SwiftShader/i,
+	/Basic Render/i,
+	/Generic Renderer/i,
+];
+
+function isSoftwareRenderer(renderer: unknown): boolean {
+	return typeof renderer === "string" && SOFTWARE_RENDERER_PATTERNS.some((p) => p.test(renderer));
+}
+
+// The sampled blob is the camoufox config fragment: the renderer strings live
+// under the spoofing keys, not top-level.
+function fingerprintRenderer(fp: { renderer?: unknown; "webGl:renderer"?: unknown }): string {
+	return typeof fp["webGl:renderer"] === "string" ? fp["webGl:renderer"] : String(fp.renderer);
+}
+
+describe("sampleWebGL weighted draw", () => {
+	test("never samples a software rasterizer", async () => {
+		const seen = new Set<string>();
+		for (let i = 0; i < 500; i++) {
+			const fp = await sampleWebGL("lin");
+			const renderer = fingerprintRenderer(fp);
+			expect(isSoftwareRenderer(renderer)).toBe(false);
+			seen.add(renderer);
+		}
+		// The filtered draw still covers the real hardware devices, it has not
+		// collapsed onto a single row.
+		expect(seen.size).toBeGreaterThan(2);
+	}, 60_000);
+
+	for (const os of ["win", "mac", "lin"] as const) {
+		test(`no software renderer wins the draw on ${os}`, async () => {
+			for (let i = 0; i < 300; i++) {
+				const fp = await sampleWebGL(os);
+				expect(isSoftwareRenderer(fingerprintRenderer(fp))).toBe(false);
+			}
+		}, 60_000);
+	}
+
+	test("explicit pairs still resolve, including software rows", async () => {
+		const pairs = await getPossiblePairs();
+		const softwarePair = pairs.lin?.find((p) => isSoftwareRenderer(p.renderer));
+		// The shipped dataset does contain llvmpipe rows for linux.
+		expect(softwarePair).toBeDefined();
+		const fp = await sampleWebGL("lin", softwarePair!.vendor, softwarePair!.renderer);
+		expect(fingerprintRenderer(fp)).toBe(softwarePair!.renderer);
+	}, 30_000);
+
+	test("unknown explicit pairs still report the full (unfiltered) pair list", async () => {
+		const pairs = await getPossiblePairs();
+		expect(Array.isArray(pairs.lin)).toBe(true);
+		expect(pairs.lin!.length).toBeGreaterThanOrEqual(11);
+	});
+});


### PR DESCRIPTION
## Problem

`sampleWebGL` draws from every `webgl_fingerprints` row with a positive OS weight. On linux the shipped dataset holds 11 devices, three of which are llvmpipe spellings — **9.0% of draws, roughly one launch in eleven** — and the drawn string is what pages read back through `WEBGL_debug_renderer_info`. A GPU-less software renderer is one of the strongest bot signals a consistency check can test for, which makes ~9% of linux launches self-defeating.

## Prior art

- **daijro/camoufox#743** (merged 2026-08-29, closing #729) removed the same bias from the python generator. From that PR: the sampler "must never come to *prefer* them, because a software renderer is a far stronger 'this is a bot' signal than any GPU/screen mismatch". This PR ports that rule to the Node implementation.
- **#276** documents the wider dataset contamination, including the software-renderer rows (~38% on linux).

## Change

One WHERE clause on the weighted-sampling branch: rows whose renderer mentions `llvmpipe`, `SwiftShader`, `Basic Render` (Microsoft Basic Render Driver) or `Generic Renderer` are excluded from the draw. The rows stay in the dataset and remain selectable through the explicit `webgl_config` vendor/renderer pair — that path is untouched, so anyone who *wants* a software-renderer fingerprint can still ask for it.

## Tests

New `test/webgl-software-renderers.test.ts` (against the shipped dataset):
- 500 draws on linux: no software renderer, and the draw still spans multiple hardware devices (not collapsed to one row)
- 300 draws each on win/mac/lin: no software renderer
- an explicit llvmpipe pair still resolves through the two-argument path
- `getPossiblePairs` still reports the full unfiltered pair list

Full suite: the only failures in this environment are the pre-existing Xvfb/browser-launch timeouts (WSL, no X11 fork server) — identical set with and without this change, verified stash-baseline vs patched. `biome check`: same findings before and after (the flagged `noNonNullAssertion` lines in `sample.ts` are pre-existing on `master`, shifted only by the added comment).

## Release note suggestion

`sampleWebGL` no longer returns software-renderer fingerprints from the weighted draw; explicit `webgl_config` pairs are unaffected.